### PR TITLE
feat(integratedreading/modes): P0 foundations — parser + SVG dispatcher + schema doc

### DIFF
--- a/.claude/skills/integratedreading/SKILL.md
+++ b/.claude/skills/integratedreading/SKILL.md
@@ -153,6 +153,18 @@ Workspace for ongoing experiments: `~/.claude/MEMORY/WORK/autoresearch-integrate
 
 ---
 
+## Reading Modes (Hardened 2026-05-14)
+
+Four new modes extend the pipeline beyond solo + composite-dyad + composite-triad: Partner-Synastry (2 subjects romantic), Business-Partners (2-3 co-founders), Family-Penta (5 kinship), Team-Synergy (4-12 team). Each delivers 12-15k meaningful words via the unified orchestrator `scripts/integratedreading-mode.ts`.
+
+**Mode-doc contract:** see [`scripts/integratedreading/modes/_schema.md`](../../../scripts/integratedreading/modes/_schema.md) for the full frontmatter contract + body section structure. One Markdown file per mode under `scripts/integratedreading/modes/<mode>.md`. The orchestrator parses this file via [`parser.ts`](../../../scripts/integratedreading/modes/parser.ts) (`parseModeDoc()`).
+
+**SVG topology routing:** mode docs declare `svg_topology: dyad-arc | triad-triangle | pentagon | web-graph`. The orchestrator dispatches via [`render/svg/index.ts`](../../../scripts/integratedreading/render/svg/index.ts) (`TOPOLOGY_RENDERERS` map). Adding a new topology = one entry in the map + one renderer module. Mode docs never name TypeScript files directly.
+
+**Design source:** [`docs/plans/2026-05-14-reading-modes-design.md`](../../../docs/plans/2026-05-14-reading-modes-design.md) — full design across 6 sections + 6-phase implementation plan tracked in milestone #1 + issues #28-#58.
+
+---
+
 ## Workflow Phases
 
 ### Phase 0 — Preflight

--- a/scripts/integratedreading/modes/_schema.md
+++ b/scripts/integratedreading/modes/_schema.md
@@ -1,0 +1,193 @@
+# Mode Document Schema
+
+Reference for authors of new reading-mode documents under `scripts/integratedreading/modes/`. One Markdown file per mode. The unified orchestrator (`scripts/integratedreading-mode.ts`) parses the file at startup via `parser.ts` and drives the entire run from what it finds here.
+
+**Design source:** [docs/plans/2026-05-14-reading-modes-design.md](../../../docs/plans/2026-05-14-reading-modes-design.md) § Section 2.
+
+---
+
+## Structure
+
+Every mode doc has three regions:
+
+1. **YAML frontmatter** between `---` delimiters at the top — declares the mode's contract (subject count, pass plan, overlays, topology).
+2. **Body sections** introduced by `## <section-name>` — prose prompt templates the orchestrator interpolates into LLM calls, plus advisory sections like glossary and interactions.
+3. **Lessons section** (`## lessons`) at the bottom — autoresearch-appended findings the orchestrator compresses into the system prompt as "what we've learned about this mode" memory.
+
+A mode doc that fails any structural rule below will fail at parse time, not at the first LLM call. Errors surface a path to the design doc.
+
+---
+
+## Frontmatter — required fields
+
+```yaml
+---
+mode: partner-synastry                   # canonical mode key — matches CLI --mode flag + filename stem
+subject_count:                           # accepted subject count range
+  min: 2
+  max: 2
+roles:                                   # ordinal slot labels — purely descriptive
+  - partner-A
+  - partner-B
+target_words:                            # acceptable output size range
+  min: 12000
+  max: 15000
+architecture: linear                     # "linear" (default) or "hierarchical"
+pass_plan:                               # ordered list of synthesis passes
+  - id: alpha
+    title: "Cross-Chart Structural Field"
+    target_words: 3000
+    template: pass-alpha-template        # name of a ## section below (no leading '##')
+    model: openai/gpt-oss-120b           # optional — falls back to SYNTH_MODELS.PRIMARY
+  - id: beta
+    title: "Pair-Resonance Threads"
+    target_words: 3500
+    template: pass-beta-template
+  - id: gamma
+    title: "Phase-Lock Geometry"
+    target_words: 3500
+    template: pass-gamma-template
+  - id: delta
+    title: "Relational Anti-Dependency Milestones"
+    target_words: 3000
+    template: pass-delta-template
+engine_overlay_weights:                  # 0.0 ignore · 1.0 baseline · 2.0 foreground
+  tarot: 2.0
+  human-design: 2.0
+  gene-keys: 1.5
+  vimshottari: 1.5
+  panchanga: 0.5
+  nadabrahman: 0.5
+house_overlay: [7, 11, 12, 5, 2]         # Vedic houses to foreground
+bridge_mandates:                         # mode-specific four-way triangulation rules
+  - "Every major claim must braid: Vedic-7th × Tarot-relational × HD-electromagnetic-channel × dasha-anchor"
+svg_topology: dyad-arc                   # one of: dyad-arc | triad-triangle | pentagon | web-graph
+---
+```
+
+### Field reference
+
+| Field | Type | Notes |
+|---|---|---|
+| `mode` | string | Canonical key. Filename stem must match (e.g. `partner-synastry.md` → `mode: partner-synastry`). |
+| `subject_count` | `{min: number, max: number}` | Inclusive range. `min === max` for fixed-N modes like family-penta (5). |
+| `roles` | string[] | Ordinal labels — descriptive only; subject identity comes from each cfg's `subject` field. |
+| `target_words` | `{min: number, max: number}` | Acceptance gate on assembled output. |
+| `architecture` | `"linear"` \| `"hierarchical"` | Linear = sequential passes. Hierarchical = outline pass first, then expansion passes that reference it. |
+| `pass_plan` | `PassSpec[]` | Ordered list, 3-6 entries typical. Each `template` must resolve to a `## section-name` in the body. |
+| `engine_overlay_weights` | `Record<string, number>` | Keyed by Selemene engine id (kebab-case). Missing engines default to 1.0. |
+| `house_overlay` | `number[]` | Vedic house numbers (1-12). |
+| `bridge_mandates` | `string[]` | Mode-specific 4-way triangulation rules. Folded into every pass system prompt. |
+| `svg_topology` | `TopologyKey` | One of `dyad-arc` / `triad-triangle` / `pentagon` / `web-graph`. Routes to the matching renderer in `render/svg/index.ts`. |
+
+### Pass spec fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | Short identifier (`alpha`, `beta`, `outline`, `exp1`, etc). Used in logs + cache filenames. |
+| `title` | string | Human-readable pass name. Shown in console output + assembled report headings. |
+| `target_words` | number | Per-pass target. Sum across all passes should fall inside `target_words` range. |
+| `template` | string | Name of a `## <name>` body section. Must exist or parse fails. |
+| `model` | string \| undefined | Optional NVIDIA model override. Defaults to `SYNTH_MODELS.PRIMARY` from autoresearch contract. |
+
+---
+
+## Body sections
+
+The orchestrator consumes these by `## section-name` (case-insensitive, lowercase-hyphenated as the parse key).
+
+### Required
+
+- **`## pass-<id>-template`** — one per entry in `pass_plan`. Prose prompt template. Available interpolation slots:
+  - `{{subject_names}}` — comma-separated list of subject names (in declared role order)
+  - `{{prior_pass}}` — last 4000 chars of accumulated output from earlier passes; empty on the first pass
+  - `{{lessons_summary}}` — compressed `## lessons` section (5 most recent entries) injected as "prior autoresearch findings" memory
+  - `{{overlay_summary}}` — derived summary of `engine_overlay_weights` + `house_overlay` for the system prompt
+  - `{{bridge_mandates}}` — pre-formatted list of bridge mandates from frontmatter
+
+### Recommended
+
+- **`## overlay-rules`** — narrative explanation of what the engine/house overlays mean for this mode. The orchestrator folds this into the system prompt as guidance.
+- **`## glossary`** — mode-specific anchor phrases the synthesis should reach for. Helps the dyad voice stay in mode-native register.
+- **`## interactions`** — describes the scroll-driven affordances + GSAP timelines for the interactive HTML output (read by `render/interactions/<mode>.ts` in Phase 2+).
+
+### Always present (may be empty initially)
+
+- **`## lessons`** — autoresearch-appended findings, date-stamped. Append-only over time.
+
+---
+
+## Lessons section format
+
+Each entry is a `### YYYY-MM-DD — <title>` heading followed by bold fields. The parser extracts the fields into structured `LessonsEntry` objects; missing fields are tolerated (lessons are advisory, not contractual).
+
+```markdown
+## lessons
+
+### 2026-05-20 — Pass γ phase-lock specificity
+**Question:** Does mandating concrete dasha-stagger-day-counts in Pass γ raise phase-lock-geometry clarity?
+**Variants:** baseline / explicit-day-count / explicit-day-count + transit-overlay
+**Winner:** explicit-day-count + transit-overlay (judge: 28.5/40 vs baseline 24/40)
+**Adopted:** Pass γ template now requires "the X-day stagger between [P1 dasha pivot] and [P2 dasha pivot]" as a structural anchor.
+**Reference:** ~/.claude/MEMORY/WORK/autoresearch-partner-synastry-2026-05-20/
+
+### 2026-06-03 — Bridge mandate strictness
+**Question:** ...
+```
+
+Field meanings:
+
+| Field | Required? | Purpose |
+|---|---|---|
+| Date | yes (in heading) | Sort order + auditability |
+| Title | yes (in heading) | Short label for the finding |
+| Question | recommended | What the autoresearch pass was testing |
+| Variants | recommended | Comma- or slash-separated list of variants tested |
+| Winner | recommended | The variant that won |
+| Adopted | recommended | What change actually landed in the mode doc |
+| Reference | recommended | Path to the autoresearch workspace with full transcripts + judge results |
+
+---
+
+## Validation rules (enforced by parser)
+
+The parser fails fast on:
+
+1. Missing leading `---` frontmatter delimiter
+2. Missing closing `---` frontmatter delimiter
+3. Malformed YAML in frontmatter
+4. Missing any required frontmatter key (`mode`, `subject_count`, `roles`, `target_words`, `architecture`, `pass_plan`, `engine_overlay_weights`, `house_overlay`, `bridge_mandates`, `svg_topology`)
+5. `svg_topology` not in `{dyad-arc, triad-triangle, pentagon, web-graph}`
+6. `architecture` not in `{linear, hierarchical}`
+7. Empty `pass_plan`
+8. Pass entry missing `id` / `title` / `template` / `target_words`
+9. `subject_count.min > subject_count.max`
+10. Any `pass_plan[].template` that doesn't resolve to a `## <name>` section in the body
+
+Out of scope for validation (intentionally — these are autoresearch-tuneable):
+- Engine overlay weight values
+- House overlay numbers
+- Bridge mandate prose quality
+- Pass target_words summing exactly to `target_words` range (advisory guidance, judged at run time)
+
+---
+
+## Authoring a new mode
+
+1. Copy `partner-synastry.md` (once it lands in P3.1) as a template — closest in structure.
+2. Update frontmatter for the new mode's contract.
+3. Write the body templates — each `## pass-<id>-template` is a complete prompt that ends with `{{prior_pass}}` and any mode-specific instructions.
+4. Add `## overlay-rules`, `## glossary`, `## interactions` (these can start as placeholders).
+5. Leave `## lessons` empty.
+6. Run `npx tsx scripts/integratedreading-mode.ts --mode <new-mode> --subjects-dir <fixture>` against a fixture; check the metric report at end of run.
+7. Once stable, kick off the per-mode autoresearch (Phase 6) — variants get appended to `## lessons` automatically.
+
+---
+
+## See also
+
+- [parser.ts](parser.ts) — the parser implementation (P0.1 deliverable)
+- [render/svg/index.ts](../render/svg/index.ts) — topology → renderer map (P0.2 deliverable)
+- [defaults.ts](../../autoresearch-integratedreading/defaults.ts) — pinned `JUDGE_MODEL`, `SYNTH_MODELS`, shared helpers
+- [SKILL.md](../../../.claude/skills/integratedreading/SKILL.md) — full skill spec including the Multi-Model Routing table + Autoresearch Contract
+- [Design doc](../../../docs/plans/2026-05-14-reading-modes-design.md) — the validated design this schema derives from

--- a/scripts/integratedreading/modes/parser.ts
+++ b/scripts/integratedreading/modes/parser.ts
@@ -1,0 +1,279 @@
+// ─── /integratedreading — Mode-doc parser ─────────────────────────────
+// Parses scripts/integratedreading/modes/<mode>.md into typed config +
+// named body sections + structured lessons list.
+//
+// One mode-doc = one mode. The orchestrator consumes the parser output;
+// mode-specific knowledge never lives in code. Per design doc § 2.
+//
+// Frontmatter spec lives in scripts/integratedreading/modes/_schema.md
+// (P0.3). Required fields enforced at parse time, not at consumption time,
+// so a malformed mode doc surfaces the error early.
+
+import { readFileSync } from 'node:fs';
+import { load as loadYAML } from 'js-yaml';
+
+// ────────────────────────────────────────────────────────────────────────
+// Types
+// ────────────────────────────────────────────────────────────────────────
+
+export type TopologyKey = 'dyad-arc' | 'triad-triangle' | 'pentagon' | 'web-graph';
+export type ArchitectureKey = 'linear' | 'hierarchical';
+
+export interface PassSpec {
+  id: string;
+  title: string;
+  target_words: number;
+  template: string;          // anchor name (lowercase-hyphenated section header)
+  model?: string;            // optional NVIDIA model override; falls back to SYNTH_MODELS.PRIMARY
+}
+
+export interface ModeConfig {
+  mode: string;
+  subject_count: { min: number; max: number };
+  roles: string[];
+  target_words: { min: number; max: number };
+  architecture: ArchitectureKey;
+  pass_plan: PassSpec[];
+  engine_overlay_weights: Record<string, number>;
+  house_overlay: number[];
+  bridge_mandates: string[];
+  svg_topology: TopologyKey;
+}
+
+export interface LessonsEntry {
+  date: string;
+  title: string;
+  question?: string;
+  variants?: string[];
+  winner?: string;
+  adopted?: string;
+  reference?: string;
+}
+
+export interface ParsedModeDoc {
+  frontmatter: ModeConfig;
+  sections: Record<string, string>;   // key = lowercase-hyphenated header (no leading '##')
+  lessons: LessonsEntry[];
+  raw_path: string;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Required-field validation
+// ────────────────────────────────────────────────────────────────────────
+
+const REQUIRED_KEYS: Array<keyof ModeConfig> = [
+  'mode',
+  'subject_count',
+  'roles',
+  'target_words',
+  'architecture',
+  'pass_plan',
+  'engine_overlay_weights',
+  'house_overlay',
+  'bridge_mandates',
+  'svg_topology',
+];
+
+const VALID_TOPOLOGIES: ReadonlyArray<TopologyKey> = [
+  'dyad-arc',
+  'triad-triangle',
+  'pentagon',
+  'web-graph',
+];
+
+const VALID_ARCHITECTURES: ReadonlyArray<ArchitectureKey> = ['linear', 'hierarchical'];
+
+function assertModeConfig(fm: any, path: string): asserts fm is ModeConfig {
+  if (!fm || typeof fm !== 'object') {
+    throw new Error(`Mode doc ${path}: frontmatter missing or not an object`);
+  }
+  for (const key of REQUIRED_KEYS) {
+    if (!(key in fm)) {
+      throw new Error(`Mode doc ${path}: missing required frontmatter key '${key}'`);
+    }
+  }
+  if (!VALID_TOPOLOGIES.includes(fm.svg_topology)) {
+    throw new Error(
+      `Mode doc ${path}: invalid svg_topology '${fm.svg_topology}'. ` +
+      `Valid: ${VALID_TOPOLOGIES.join(' | ')}`,
+    );
+  }
+  if (!VALID_ARCHITECTURES.includes(fm.architecture)) {
+    throw new Error(
+      `Mode doc ${path}: invalid architecture '${fm.architecture}'. ` +
+      `Valid: ${VALID_ARCHITECTURES.join(' | ')}`,
+    );
+  }
+  if (!Array.isArray(fm.pass_plan) || fm.pass_plan.length === 0) {
+    throw new Error(`Mode doc ${path}: pass_plan must be a non-empty array`);
+  }
+  for (const [i, p] of fm.pass_plan.entries()) {
+    if (!p.id || !p.title || !p.template || typeof p.target_words !== 'number') {
+      throw new Error(
+        `Mode doc ${path}: pass_plan[${i}] missing one of {id, title, template, target_words}`,
+      );
+    }
+  }
+  if (typeof fm.subject_count?.min !== 'number' || typeof fm.subject_count?.max !== 'number') {
+    throw new Error(`Mode doc ${path}: subject_count.{min,max} must be numbers`);
+  }
+  if (fm.subject_count.min > fm.subject_count.max) {
+    throw new Error(`Mode doc ${path}: subject_count.min > subject_count.max`);
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Frontmatter + body split
+// ────────────────────────────────────────────────────────────────────────
+
+const FRONTMATTER_DELIMITER = '---';
+
+interface SplitResult {
+  yaml: string;
+  body: string;
+}
+
+function splitFrontmatter(raw: string, path: string): SplitResult {
+  if (!raw.startsWith(FRONTMATTER_DELIMITER)) {
+    throw new Error(`Mode doc ${path}: missing leading '---' frontmatter delimiter`);
+  }
+  const closeIdx = raw.indexOf('\n' + FRONTMATTER_DELIMITER, FRONTMATTER_DELIMITER.length);
+  if (closeIdx === -1) {
+    throw new Error(`Mode doc ${path}: missing closing '---' frontmatter delimiter`);
+  }
+  const yaml = raw.slice(FRONTMATTER_DELIMITER.length, closeIdx).trim();
+  // Skip past the closing delimiter line
+  const bodyStart = raw.indexOf('\n', closeIdx + FRONTMATTER_DELIMITER.length + 1);
+  const body = bodyStart === -1 ? '' : raw.slice(bodyStart + 1);
+  return { yaml, body };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Body section splitter
+// ────────────────────────────────────────────────────────────────────────
+
+/** Split body by `## <header>` lines. Returns map keyed by slug. */
+function splitSections(body: string): Record<string, string> {
+  const sections: Record<string, string> = {};
+  const headerRe = /^## (.+?)\s*$/gm;
+  const matches: Array<{ slug: string; index: number; headerEnd: number }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = headerRe.exec(body)) !== null) {
+    const slug = m[1]
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+    matches.push({ slug, index: m.index, headerEnd: m.index + m[0].length });
+  }
+  for (let i = 0; i < matches.length; i++) {
+    const start = matches[i].headerEnd;
+    const end = i + 1 < matches.length ? matches[i + 1].index : body.length;
+    sections[matches[i].slug] = body.slice(start, end).trim();
+  }
+  return sections;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Lessons section parser
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parses the `## lessons` section into structured entries.
+ *
+ * Entry shape (per design doc § 4):
+ *
+ *   ### YYYY-MM-DD — <title>
+ *   **Question:** <question>
+ *   **Variants:** <variants>
+ *   **Winner:** <winner>
+ *   **Adopted:** <adopted>
+ *   **Reference:** <reference>
+ *
+ * Empty section returns []. Malformed entries return whatever bold fields
+ * parse cleanly — lessons are advisory, not contractual.
+ */
+function parseLessons(lessonsBody: string | undefined): LessonsEntry[] {
+  if (!lessonsBody || !lessonsBody.trim()) return [];
+  const entries: LessonsEntry[] = [];
+  const entryRe = /^### (\d{4}-\d{2}-\d{2})\s*[—–-]\s*(.+?)$/gm;
+  const headers: Array<{ date: string; title: string; index: number; headerEnd: number }> = [];
+  let m: RegExpExecArray | null;
+  while ((m = entryRe.exec(lessonsBody)) !== null) {
+    headers.push({
+      date: m[1],
+      title: m[2].trim(),
+      index: m.index,
+      headerEnd: m.index + m[0].length,
+    });
+  }
+  for (let i = 0; i < headers.length; i++) {
+    const body = lessonsBody.slice(
+      headers[i].headerEnd,
+      i + 1 < headers.length ? headers[i + 1].index : lessonsBody.length,
+    );
+    const fields: Partial<LessonsEntry> = {};
+    for (const fieldName of ['Question', 'Variants', 'Winner', 'Adopted', 'Reference'] as const) {
+      const re = new RegExp(`\\*\\*${fieldName}:\\*\\*\\s*(.+?)(?=\\n\\*\\*|\\n\\n|$)`, 's');
+      const fm = body.match(re);
+      if (fm) {
+        const value = fm[1].trim();
+        if (fieldName === 'Variants') {
+          fields.variants = value.split(/[,\/]\s*/).map((v) => v.trim()).filter(Boolean);
+        } else {
+          (fields as any)[fieldName.toLowerCase()] = value;
+        }
+      }
+    }
+    entries.push({ date: headers[i].date, title: headers[i].title, ...fields });
+  }
+  return entries;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Public API
+// ────────────────────────────────────────────────────────────────────────
+
+/** Parse a mode-doc Markdown file at `path`. Throws on missing required fields. */
+export function parseModeDoc(path: string): ParsedModeDoc {
+  const raw = readFileSync(path, 'utf-8');
+  const { yaml, body } = splitFrontmatter(raw, path);
+
+  let frontmatter: any;
+  try {
+    frontmatter = loadYAML(yaml);
+  } catch (err: any) {
+    throw new Error(`Mode doc ${path}: malformed YAML frontmatter — ${err.message}`);
+  }
+
+  assertModeConfig(frontmatter, path);
+
+  const sections = splitSections(body);
+  const lessons = parseLessons(sections.lessons);
+
+  // pass_plan templates must resolve to actual sections in the body
+  for (const pass of frontmatter.pass_plan) {
+    if (!sections[pass.template]) {
+      throw new Error(
+        `Mode doc ${path}: pass_plan[${pass.id}].template '${pass.template}' has no matching '## ${pass.template}' section`,
+      );
+    }
+  }
+
+  return {
+    frontmatter,
+    sections,
+    lessons,
+    raw_path: path,
+  };
+}
+
+/** Render a compressed summary of the lessons section for system-prompt injection. */
+export function summarizeLessons(lessons: LessonsEntry[], maxEntries = 5): string {
+  if (lessons.length === 0) return '';
+  const recent = lessons.slice(-maxEntries);
+  const lines = recent.map((l) => {
+    const adopted = l.adopted ? ` — Adopted: ${l.adopted}` : '';
+    return `• ${l.date} ${l.title}${adopted}`;
+  });
+  return `## Prior Autoresearch Findings\n\n${lines.join('\n')}`;
+}

--- a/scripts/integratedreading/render/svg/index.ts
+++ b/scripts/integratedreading/render/svg/index.ts
@@ -1,0 +1,103 @@
+// ─── /integratedreading — SVG Renderer Dispatcher ─────────────────────
+// Single source of truth mapping `svg_topology` keys (declared in mode-doc
+// frontmatter) to their renderer functions. The unified orchestrator
+// (integratedreading-mode.ts, P1.1) and the HTML templates layer route
+// through this dispatcher rather than importing renderers directly.
+//
+// Adding a new topology = adding one entry to TOPOLOGY_RENDERERS. The
+// orchestrator + interaction modules + tests pick it up automatically.
+//
+// Per design doc § 5 (svg_topology → renderer map) and § 6 phase 0.2.
+
+import type { TopologyKey } from '../../modes/parser.js';
+import { renderCompositeResonance, type CompositeResonanceData } from './composite-resonance.js';
+import { renderCompositeTriad, type CompositeTriadData } from './composite-triad.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// Renderer function shape
+// ────────────────────────────────────────────────────────────────────────
+
+export interface RendererOpts {
+  width?: number;
+  /** Reserved for P2 — when true, renderer emits SVG with class hooks for
+   *  the interaction layer to target. Renderers may ignore until P2.2. */
+  interactive?: boolean;
+}
+
+export interface RendererFn<TData = any> {
+  (data: TData, opts?: RendererOpts): string;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// NotImplementedError — thrown by stub topologies until their renderer
+// lands in P4.2 / P5.2.
+// ────────────────────────────────────────────────────────────────────────
+
+class NotImplementedError extends Error {
+  constructor(topology: TopologyKey, landing_issue: string) {
+    super(
+      `SVG topology '${topology}' is not yet implemented. ` +
+      `It lands in ${landing_issue}. ` +
+      `See docs/plans/2026-05-14-reading-modes-design.md § Section 5 for the design.`,
+    );
+    this.name = 'NotImplementedError';
+  }
+}
+
+function pentagonStub(_data: any, _opts?: RendererOpts): string {
+  throw new NotImplementedError('pentagon', 'issue #50 (P4.2)');
+}
+
+function webGraphStub(_data: any, _opts?: RendererOpts): string {
+  throw new NotImplementedError('web-graph', 'issue #53 (P5.2)');
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Registry
+// ────────────────────────────────────────────────────────────────────────
+
+export const TOPOLOGY_RENDERERS: Record<TopologyKey, RendererFn<any>> = {
+  'dyad-arc': renderCompositeResonance as RendererFn<CompositeResonanceData>,
+  'triad-triangle': renderCompositeTriad as RendererFn<CompositeTriadData>,
+  'pentagon': pentagonStub,
+  'web-graph': webGraphStub,
+};
+
+// ────────────────────────────────────────────────────────────────────────
+// Public dispatcher
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Look up a renderer by topology key.
+ *
+ * Throws a clear error (with the list of valid keys) on unknown topology
+ * — this catches typos in mode-doc frontmatter at run time instead of
+ * silently emitting a blank SVG.
+ */
+export function getRenderer(topology: string): RendererFn<any> {
+  const fn = TOPOLOGY_RENDERERS[topology as TopologyKey];
+  if (!fn) {
+    throw new Error(
+      `Unknown svg_topology '${topology}'. ` +
+      `Valid topologies: ${Object.keys(TOPOLOGY_RENDERERS).join(' | ')}`,
+    );
+  }
+  return fn;
+}
+
+/** Convenience: dispatch + render in one call. */
+export function renderByTopology(
+  topology: string,
+  data: any,
+  opts?: RendererOpts,
+): string {
+  return getRenderer(topology)(data, opts);
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Re-exports — keeps the rest of the codebase importing from one place.
+// ────────────────────────────────────────────────────────────────────────
+
+export type { TopologyKey } from '../../modes/parser.js';
+export { renderCompositeResonance, type CompositeResonanceData } from './composite-resonance.js';
+export { renderCompositeTriad, type CompositeTriadData, type TriadSubject } from './composite-triad.js';

--- a/tests/mode-parser.test.ts
+++ b/tests/mode-parser.test.ts
@@ -1,0 +1,354 @@
+// ─── Mode-doc parser + SVG dispatcher tests ───────────────────────────
+// Covers P0.1 (parser) and P0.2 (dispatcher) from the reading-modes plan.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { parseModeDoc, summarizeLessons } from '../scripts/integratedreading/modes/parser.js';
+import {
+  TOPOLOGY_RENDERERS,
+  getRenderer,
+  renderByTopology,
+} from '../scripts/integratedreading/render/svg/index.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────
+
+function makeTempDoc(content: string): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'mode-doc-test-'));
+  const path = join(dir, 'sample.md');
+  writeFileSync(path, content, 'utf-8');
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+const VALID_DOC = `---
+mode: partner-synastry
+subject_count:
+  min: 2
+  max: 2
+roles:
+  - partner-A
+  - partner-B
+target_words:
+  min: 12000
+  max: 15000
+architecture: linear
+pass_plan:
+  - id: alpha
+    title: "Cross-Chart Structural Field"
+    target_words: 3000
+    template: pass-alpha-template
+  - id: beta
+    title: "Pair-Resonance Threads"
+    target_words: 3500
+    template: pass-beta-template
+engine_overlay_weights:
+  tarot: 2.0
+  human-design: 2.0
+house_overlay: [7, 11, 12]
+bridge_mandates:
+  - "Every claim braids four cross-system references."
+svg_topology: dyad-arc
+---
+
+## pass-alpha-template
+
+Write Pass α — the structural cross-chart field.
+
+{{prior_pass}}
+
+## pass-beta-template
+
+Write Pass β — pair-resonance threads.
+
+{{prior_pass}}
+
+## overlay-rules
+
+Tarot and HD are foregrounded for romantic synastry.
+
+## glossary
+
+phase-lock geometry, AKSHARA-coupling.
+
+## interactions
+
+Hover threads → tooltip names the four-way bridge.
+
+## lessons
+
+### 2026-05-20 — Pass γ phase-lock specificity
+**Question:** Does mandating concrete dasha-stagger-day-counts in Pass γ raise phase-lock-geometry clarity?
+**Variants:** baseline / explicit-day-count / explicit-day-count + transit-overlay
+**Winner:** explicit-day-count + transit-overlay (judge: 28.5/40 vs baseline 24/40)
+**Adopted:** Pass γ template requires "the X-day stagger" structural anchor.
+**Reference:** ~/.claude/MEMORY/WORK/autoresearch-partner-synastry-2026-05-20/
+`;
+
+// ────────────────────────────────────────────────────────────────────────
+// Parser — happy path
+// ────────────────────────────────────────────────────────────────────────
+
+describe('parseModeDoc — happy path', () => {
+  it('parses a full valid mode doc', () => {
+    const { path, cleanup } = makeTempDoc(VALID_DOC);
+    try {
+      const result = parseModeDoc(path);
+      assert.equal(result.frontmatter.mode, 'partner-synastry');
+      assert.equal(result.frontmatter.subject_count.min, 2);
+      assert.equal(result.frontmatter.subject_count.max, 2);
+      assert.deepEqual(result.frontmatter.roles, ['partner-A', 'partner-B']);
+      assert.equal(result.frontmatter.architecture, 'linear');
+      assert.equal(result.frontmatter.pass_plan.length, 2);
+      assert.equal(result.frontmatter.svg_topology, 'dyad-arc');
+      assert.equal(result.frontmatter.engine_overlay_weights.tarot, 2.0);
+      assert.deepEqual(result.frontmatter.house_overlay, [7, 11, 12]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('splits body into named sections (lowercase-hyphenated keys)', () => {
+    const { path, cleanup } = makeTempDoc(VALID_DOC);
+    try {
+      const result = parseModeDoc(path);
+      assert.ok(result.sections['pass-alpha-template']);
+      assert.ok(result.sections['pass-beta-template']);
+      assert.ok(result.sections['overlay-rules']);
+      assert.ok(result.sections['glossary']);
+      assert.ok(result.sections['interactions']);
+      assert.ok(result.sections['lessons']);
+      assert.match(result.sections['pass-alpha-template'], /structural cross-chart field/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('parses lessons section into structured entries', () => {
+    const { path, cleanup } = makeTempDoc(VALID_DOC);
+    try {
+      const result = parseModeDoc(path);
+      assert.equal(result.lessons.length, 1);
+      const entry = result.lessons[0];
+      assert.equal(entry.date, '2026-05-20');
+      assert.equal(entry.title, 'Pass γ phase-lock specificity');
+      assert.match(entry.question || '', /dasha-stagger-day-counts/);
+      assert.equal(entry.variants?.length, 3);
+      assert.match(entry.winner || '', /explicit-day-count \+ transit-overlay/);
+      assert.match(entry.adopted || '', /X-day stagger/);
+      assert.match(entry.reference || '', /autoresearch-partner-synastry/);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Parser — error paths
+// ────────────────────────────────────────────────────────────────────────
+
+describe('parseModeDoc — error paths', () => {
+  it('throws on missing frontmatter delimiter', () => {
+    const { path, cleanup } = makeTempDoc('no frontmatter here\n## section\nbody\n');
+    try {
+      assert.throws(() => parseModeDoc(path), /missing leading.*frontmatter/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('throws on missing closing frontmatter delimiter', () => {
+    const { path, cleanup } = makeTempDoc('---\nmode: x\n\n## section\nbody\n');
+    try {
+      assert.throws(() => parseModeDoc(path), /missing closing.*frontmatter/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('throws on missing required frontmatter key', () => {
+    const incomplete = `---
+mode: x
+subject_count:
+  min: 2
+  max: 2
+---
+
+## anything
+body
+`;
+    const { path, cleanup } = makeTempDoc(incomplete);
+    try {
+      assert.throws(() => parseModeDoc(path), /missing required frontmatter key/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('throws on invalid svg_topology', () => {
+    const bad = VALID_DOC.replace('svg_topology: dyad-arc', 'svg_topology: octagon');
+    const { path, cleanup } = makeTempDoc(bad);
+    try {
+      assert.throws(() => parseModeDoc(path), /invalid svg_topology/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('throws when pass_plan.template references a missing section', () => {
+    const bad = VALID_DOC.replace(
+      'template: pass-alpha-template',
+      'template: nonexistent-template',
+    );
+    const { path, cleanup } = makeTempDoc(bad);
+    try {
+      assert.throws(() => parseModeDoc(path), /has no matching.*section/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('throws when subject_count.min > max', () => {
+    const bad = VALID_DOC.replace('min: 2\n  max: 2', 'min: 5\n  max: 2');
+    const { path, cleanup } = makeTempDoc(bad);
+    try {
+      assert.throws(() => parseModeDoc(path), /min > subject_count\.max/);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Parser — empty/missing lessons
+// ────────────────────────────────────────────────────────────────────────
+
+describe('parseModeDoc — lessons edge cases', () => {
+  it('handles empty lessons section', () => {
+    const withEmptyLessons = VALID_DOC.replace(/## lessons[\s\S]*$/, '## lessons\n');
+    const { path, cleanup } = makeTempDoc(withEmptyLessons);
+    try {
+      const result = parseModeDoc(path);
+      assert.deepEqual(result.lessons, []);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('handles entirely missing lessons section', () => {
+    const noLessons = VALID_DOC.replace(/## lessons[\s\S]*$/, '');
+    const { path, cleanup } = makeTempDoc(noLessons);
+    try {
+      const result = parseModeDoc(path);
+      assert.deepEqual(result.lessons, []);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// summarizeLessons
+// ────────────────────────────────────────────────────────────────────────
+
+describe('summarizeLessons', () => {
+  it('returns empty string when no lessons', () => {
+    assert.equal(summarizeLessons([]), '');
+  });
+
+  it('summarizes recent entries with adopted line', () => {
+    const out = summarizeLessons([
+      { date: '2026-05-01', title: 'first', adopted: 'use X' },
+      { date: '2026-05-10', title: 'second' },
+    ]);
+    assert.match(out, /Prior Autoresearch Findings/);
+    assert.match(out, /2026-05-01 first.*Adopted: use X/);
+    assert.match(out, /2026-05-10 second/);
+  });
+
+  it('clips to maxEntries (default 5)', () => {
+    const entries = Array.from({ length: 8 }, (_, i) => ({
+      date: `2026-05-0${i + 1}`,
+      title: `entry-${i}`,
+    }));
+    const out = summarizeLessons(entries);
+    // Last 5: entry-3 through entry-7
+    assert.ok(!out.includes('entry-0'));
+    assert.ok(!out.includes('entry-1'));
+    assert.ok(!out.includes('entry-2'));
+    assert.ok(out.includes('entry-3'));
+    assert.ok(out.includes('entry-7'));
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// SVG renderer-dispatcher (P0.2)
+// ────────────────────────────────────────────────────────────────────────
+
+describe('SVG renderer-dispatcher', () => {
+  it('registers all four topology keys', () => {
+    const keys = Object.keys(TOPOLOGY_RENDERERS).sort();
+    assert.deepEqual(keys, ['dyad-arc', 'pentagon', 'triad-triangle', 'web-graph']);
+  });
+
+  it('getRenderer returns a callable for valid topology', () => {
+    const r = getRenderer('dyad-arc');
+    assert.equal(typeof r, 'function');
+  });
+
+  it('getRenderer throws clear error on unknown topology', () => {
+    assert.throws(
+      () => getRenderer('octagon'),
+      /Unknown svg_topology.*octagon.*Valid topologies/,
+    );
+  });
+
+  it('renderByTopology dyad-arc emits valid SVG string', () => {
+    const data = {
+      subject_a: 'Alice',
+      subject_b: 'Bob',
+      a_mahadasha: { current: 'Rahu', next: 'Jupiter', transition_iso: '2026-09-14' },
+      b_mahadasha: { current: 'Ketu', next: 'Venus', transition_iso: '2026-11-18' },
+      electromagnetic_channels: ['24-61 Awareness'],
+      companionship_gates: ['31', '62'],
+    };
+    const svg = renderByTopology('dyad-arc', data, { width: 640 });
+    assert.match(svg, /<svg xmlns/);
+    assert.match(svg, /<\/svg>/);
+    assert.match(svg, /ALICE/);
+    assert.match(svg, /BOB/);
+  });
+
+  it('renderByTopology triad-triangle emits valid SVG string', () => {
+    const data = {
+      subjects: [
+        { name: 'Alice', arc_color: '#10B5A7', current_mahadasha_lord: 'Rahu', next_mahadasha_lord: 'Jupiter', next_mahadasha_iso: '2026-09-14' },
+        { name: 'Bob', arc_color: '#0B50FB', current_mahadasha_lord: 'Ketu', next_mahadasha_lord: 'Venus', next_mahadasha_iso: '2026-11-18' },
+        { name: 'Carol', arc_color: '#C5A017', current_mahadasha_lord: 'Mars', next_mahadasha_lord: 'Rahu', next_mahadasha_iso: '2027-11-10' },
+      ],
+      shared_keys: ['Wheel of Fortune'],
+    };
+    const svg = renderByTopology('triad-triangle', data, { width: 720 });
+    assert.match(svg, /<svg xmlns/);
+    assert.match(svg, /TRIAD/);
+    assert.match(svg, /ALICE/);
+  });
+
+  it('pentagon topology throws NotImplementedError pointing to issue #50', () => {
+    assert.throws(
+      () => renderByTopology('pentagon', {}),
+      /not yet implemented.*#50/,
+    );
+  });
+
+  it('web-graph topology throws NotImplementedError pointing to issue #53', () => {
+    assert.throws(
+      () => renderByTopology('web-graph', {}),
+      /not yet implemented.*#53/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Phase 0 of the reading-modes plan. Lands the substrate the unified orchestrator (Phase 1) and all mode docs (Phases 3-5) depend on. No new modes ship here; no behavior changes for existing modes.

Bundled into one PR per design doc § 6 (Phase 0 scope: 1 PR, ~400 LOC; actual: ~940 lines including tests + schema doc).

## Closes
- Closes #35 — P0.1 mode-doc parser
- Closes #36 — P0.2 SVG renderer-dispatcher
- Closes #37 — P0.3 mode-doc frontmatter schema documentation

## What changed
**New**: `scripts/integratedreading/modes/parser.ts` (279 LOC)
- `parseModeDoc(path)` → `{frontmatter, sections, lessons, raw_path}`
- Uses existing `js-yaml` dep — no new dependencies
- Fails fast on missing required fields, invalid topology/architecture, dangling template references
- `summarizeLessons()` helper for system-prompt injection

**New**: `scripts/integratedreading/render/svg/index.ts` (103 LOC)
- `TOPOLOGY_RENDERERS` map keyed by `dyad-arc` / `triad-triangle` / `pentagon` / `web-graph`
- Existing renderers (composite-resonance, composite-triad) registered behind their topology keys
- Pentagon + web-graph throw `NotImplementedError` pointing at #50 + #53
- `getRenderer()` + `renderByTopology()` helpers

**New**: `scripts/integratedreading/modes/_schema.md` (193 LOC)
- Full frontmatter contract documentation
- Field reference table
- Lessons entry format
- Parser validation rules (the fail-fast list)
- Step-by-step authoring guide

**New**: `tests/mode-parser.test.ts` (354 LOC, 21 tests, all passing)
- Parser happy path: full doc parse, section splitting, structured lessons
- Parser error paths: missing delimiters, missing required keys, invalid topology, dangling refs, min > max
- Lessons edge cases: empty section, no section at all
- `summarizeLessons`: 5-entry cap behavior
- SVG dispatcher: topology map completeness, unknown topology error, render-emits-valid-SVG, stub-throws

**Updated**: `.claude/skills/integratedreading/SKILL.md`
- New section "Reading Modes (Hardened 2026-05-14)" cross-linking parser, dispatcher, schema doc, design

## Verification
- 21/21 tests pass in 222ms (`node --import tsx --test tests/mode-parser.test.ts`)
- Existing renderers emit identical SVG strings through the dispatcher (backwards compatible)
- `js-yaml` already a project dep (no new dependencies added)

## Test plan
- [ ] Run \`node --import tsx --test tests/mode-parser.test.ts\` → 21/21 pass
- [ ] Import \`parseModeDoc\` from a downstream consumer — TypeScript types resolve cleanly
- [ ] Read \`_schema.md\` cold — would a fresh contributor know how to author a new mode?

🤖 Generated with [Claude Code](https://claude.com/claude-code)