### PR TITLE
feat(integratedreading): P1 unified orchestrator + port composite/triad as mode docs

### DIFF
--- a/scripts/integratedreading-composite.ts
+++ b/scripts/integratedreading-composite.ts
@@ -1,275 +1,65 @@
-// ─── /integratedreading — Synastry / Composite Mode ─────────────────
-// Takes two completed solo readings (their .runs/<ts>/06_synthesis_*.md outputs)
-// and produces a dyadic composite reading + HTML/PDF.
+#!/usr/bin/env node --import tsx
+// ─── /integratedreading — Composite Dyad (LEGACY SHIM) ─────────────────
 //
-// Honors Hardened Reference Data principle: chart placements come from each
-// subject's config (docx-extracted). Selemene cross-resonance is augmentation,
-// not source of truth.
+// This file is a thin compatibility shim. The canonical implementation now
+// lives in `scripts/integratedreading-mode.ts` driven by the mode doc at
+// `scripts/integratedreading/modes/composite-dyad.md`.
 //
-// Usage:
-//   node --import tsx scripts/integratedreading-composite.ts \
-//     --subject-a <subject-a-config.json> \
-//     --subject-b <subject-b-config.json> \
-//     --output-dir <dir> \
-//     [--use-cache]
+// The shim translates legacy CLI flags (--subject-a / --subject-b /
+// --output-dir / --use-cache) into the new orchestrator's contract
+// (--mode composite-dyad / --subjects-dir / --output-dir / --use-cache)
+// by materializing a temporary subjects-directory.
+//
+// Preserves CI / external workflows that still invoke this filename
+// directly. New work should call `integratedreading-mode.ts` directly.
+//
+// Closes #41 (P1.4) — composite half.
 
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { join, resolve, basename } from 'node:path';
-import { execSync } from 'node:child_process';
-import { homedir } from 'node:os';
-import { findOrCreateCachedRunDir } from './autoresearch-integratedreading/defaults.js';
+import { mkdtempSync, copyFileSync, existsSync } from 'node:fs';
+import { join, resolve, basename, dirname } from 'node:path';
+import { spawn } from 'node:child_process';
+import { tmpdir } from 'node:os';
 
-import { NvidiaClient, MODELS } from './integratedreading/nvidia-client.js';
-import {
-  ANATOMIST_PERSONA,
-  KOSHA_GRAMMAR,
-  DYADIC_LOOP,
-  compositePrompt,
-} from './integratedreading/system-prompts.js';
-import { renderHTMLPage, renderPart, renderViz } from './integratedreading/render/templates.js';
-import { renderCompositeResonance } from './integratedreading/render/svg/composite-resonance.js';
-import { renderKundaliChart } from './integratedreading/render/svg/kundali-chart.js';
-
-// ──────────────────────────────────────────────────────────────────────
-
-interface SubjectConfig {
-  source_path?: string;
-  subject: string;
-  birth_date: string;
-  birth_time?: string;
-  birth_place?: string;
-  lagna: string;
-  atmakaraka?: string;
-  placements: any[];
-  mahadasha?: {
-    current_lord: string;
-    current_ends_iso?: string;
-    next_lord: string;
-    next_starts_iso?: string;
-    next_duration_years?: number;
-  };
-  output_dir: string;
-}
-
-function getArg(name: string, fallback?: string): string | undefined {
+function getArg(name: string): string | undefined {
   const idx = process.argv.indexOf(`--${name}`);
   if (idx > 0 && idx + 1 < process.argv.length) return process.argv[idx + 1];
-  return fallback;
-}
-function hasFlag(name: string): boolean { return process.argv.includes(`--${name}`); }
-
-function loadNvidiaKey(): string {
-  if (process.env.NVIDIA_API_KEY) return process.env.NVIDIA_API_KEY;
-  const envPath = join(homedir(), '.claude', '.env');
-  if (existsSync(envPath)) {
-    const m = readFileSync(envPath, 'utf-8').match(/^NVIDIA_API_KEY=(\S+)/m);
-    if (m) { process.env.NVIDIA_API_KEY = m[1]; return m[1]; }
-  }
-  throw new Error('NVIDIA_API_KEY not found in env');
-}
-
-function mdToHtml(md: string): string {
-  if (!md.trim()) return '';
-  try {
-    return execSync('pandoc -f markdown -t html5 --syntax-highlighting=none', { input: md, encoding: 'utf-8' });
-  } catch { return md.split(/\n\n+/).map((p) => `<p>${p}</p>`).join('\n'); }
-}
-
-function findLatestRun(outputDir: string, slug: string): string | undefined {
-  const runsRoot = join(outputDir, '.runs');
-  if (!existsSync(runsRoot)) return undefined;
-  const dirs = readdirSync(runsRoot).filter((d) => /^\d{4}-/.test(d)).sort().reverse();
-  for (const d of dirs) {
-    const synthPath = join(runsRoot, d, `06_synthesis_${slug}.md`);
-    if (existsSync(synthPath)) return join(runsRoot, d);
-  }
   return undefined;
 }
-
-function slugify(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9]/g, '-').replace(/-+/g, '-');
+function hasFlag(name: string): boolean {
+  return process.argv.includes(`--${name}`);
 }
 
-// ──────────────────────────────────────────────────────────────────────
+const subjectA = getArg('subject-a');
+const subjectB = getArg('subject-b');
+const outputDir = getArg('output-dir');
+const useCache = hasFlag('use-cache');
 
-const CHROME_BIN = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
-function exportPDF(htmlPath: string, pdfPath: string): boolean {
-  if (!existsSync(CHROME_BIN)) return false;
-  try {
-    execSync(`"${CHROME_BIN}" --headless --disable-gpu --no-pdf-header-footer --print-to-pdf-no-header --print-to-pdf="${pdfPath}" --virtual-time-budget=10000 --hide-scrollbars "file://${htmlPath}"`,
-      { stdio: 'pipe', timeout: 90_000 });
-    return existsSync(pdfPath);
-  } catch (err: any) {
-    console.warn(`  ⚠ PDF: ${err.message.slice(0, 100)}`);
-    return false;
-  }
+if (!subjectA || !subjectB || !outputDir) {
+  console.error('Usage: integratedreading-composite.ts --subject-a <cfg.json> --subject-b <cfg.json> --output-dir <dir> [--use-cache]');
+  console.error('');
+  console.error('NOTE: This is a deprecation shim. Prefer:');
+  console.error('  integratedreading-mode.ts --mode composite-dyad --subjects-dir <dir> --output-dir <dir>');
+  process.exit(1);
 }
 
-// ──────────────────────────────────────────────────────────────────────
+if (!existsSync(subjectA)) { console.error(`Subject A config not found: ${subjectA}`); process.exit(1); }
+if (!existsSync(subjectB)) { console.error(`Subject B config not found: ${subjectB}`); process.exit(1); }
 
-async function main() {
-  const configA = getArg('subject-a');
-  const configB = getArg('subject-b');
-  const outputDir = getArg('output-dir') || '/tmp/composite-output';
-  const useCache = hasFlag('use-cache');
-  if (!configA || !configB) {
-    console.error('Usage: integratedreading-composite.ts --subject-a <cfg.json> --subject-b <cfg.json> --output-dir <dir>');
-    process.exit(1);
-  }
+console.warn('[deprecation] integratedreading-composite.ts is a shim — prefer integratedreading-mode.ts --mode composite-dyad');
 
-  const cfgA: SubjectConfig = JSON.parse(await readFile(configA, 'utf-8'));
-  const cfgB: SubjectConfig = JSON.parse(await readFile(configB, 'utf-8'));
-  const slugA = slugify(cfgA.subject);
-  const slugB = slugify(cfgB.subject);
-  const dyadSlug = `${slugA}-x-${slugB}`;
+// Materialize a temporary subjects-directory with the ordinal-prefix convention
+const subjectsDir = mkdtempSync(join(tmpdir(), 'composite-dyad-subjects-'));
+copyFileSync(resolve(subjectA), join(subjectsDir, '01_' + basename(subjectA)));
+copyFileSync(resolve(subjectB), join(subjectsDir, '02_' + basename(subjectB)));
 
-  await mkdir(outputDir, { recursive: true });
-  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-  // Cache-aware run-dir: shared helper. Reuses prior run that has the
-  // composite cache file present; otherwise creates a fresh ts dir.
-  const { runDir, reusedPrior } = findOrCreateCachedRunDir({
-    outputDir,
-    freshTs: ts,
-    useCache,
-    cacheFileName: `08_composite_${dyadSlug}.md`,
-  });
-  if (reusedPrior) console.log(`  ↻ Reusing prior run dir for --use-cache`);
+const orchestratorPath = join(dirname(new URL(import.meta.url).pathname), 'integratedreading-mode.ts');
+const args = ['--import', 'tsx', orchestratorPath,
+  '--mode', 'composite-dyad',
+  '--subjects-dir', subjectsDir,
+  '--output-dir', resolve(outputDir),
+];
+if (useCache) args.push('--use-cache');
 
-  console.log('═══ integratedreading-composite ═══');
-  console.log(`  Subject A: ${cfgA.subject}`);
-  console.log(`  Subject B: ${cfgB.subject}`);
-  console.log(`  Output:    ${outputDir}`);
-  console.log(`  Run:       ${runDir}`);
-
-  // Load both subjects' synthesis from their respective .runs/<ts>/ dirs
-  const runDirA = findLatestRun(cfgA.output_dir, slugA);
-  const runDirB = findLatestRun(cfgB.output_dir, slugB);
-  if (!runDirA || !runDirB) {
-    console.error(`FATAL: Could not find synthesis for both subjects. Run solo pipelines first.`);
-    console.error(`  A run dir: ${runDirA || '(not found)'}`);
-    console.error(`  B run dir: ${runDirB || '(not found)'}`);
-    process.exit(1);
-  }
-  const synthA = await readFile(join(runDirA, `06_synthesis_${slugA}.md`), 'utf-8');
-  const synthB = await readFile(join(runDirB, `06_synthesis_${slugB}.md`), 'utf-8');
-  console.log(`  ✓ Loaded synthesis A (${synthA.split(/\s+/).length.toLocaleString()} words)`);
-  console.log(`  ✓ Loaded synthesis B (${synthB.split(/\s+/).length.toLocaleString()} words)`);
-
-  // Cross-resonance derived from BOTH docx mahadasha values (hardened truth, no Selemene drift)
-  const crossResonance = {
-    a_mahadasha: cfgA.mahadasha,
-    b_mahadasha: cfgB.mahadasha,
-    mahadasha_overlap_window: cfgA.mahadasha && cfgB.mahadasha ? {
-      a_pivot: cfgA.mahadasha.current_ends_iso,
-      b_pivot: cfgB.mahadasha.current_ends_iso,
-      grace_node_joint_years: Math.min(cfgA.mahadasha.next_duration_years || 0, cfgB.mahadasha.next_duration_years || 0),
-    } : null,
-    a_atmakaraka: cfgA.atmakaraka,
-    b_atmakaraka: cfgB.atmakaraka,
-    note: cfgA.atmakaraka && cfgB.atmakaraka && cfgA.atmakaraka.toLowerCase() === cfgB.atmakaraka.toLowerCase()
-      ? `Shared Atmakaraka: ${cfgA.atmakaraka} — same soul-signifier graha in both charts (rare Vijnanamaya-layer coupling).`
-      : `Different Atmakarakas (${cfgA.atmakaraka} vs ${cfgB.atmakaraka}) — complementary soul-signifier configuration.`,
-  };
-
-  // Run composite synthesis via NVIDIA (gpt-oss-120b, single pass — composite is shorter than solo)
-  const compositeCachePath = join(runDir, `08_composite_${dyadSlug}.md`);
-  let composite: string;
-  if (useCache && existsSync(compositeCachePath)) {
-    composite = await readFile(compositeCachePath, 'utf-8');
-    console.log(`  ✓ Composite cached`);
-  } else {
-    console.log(`  → Composite synthesis (gpt-oss-120b)...`);
-    const nvidia = new NvidiaClient(loadNvidiaKey());
-    const res = await nvidia.callWithRetry({
-      model: MODELS.GPT_OSS_120B,
-      messages: [
-        { role: 'system', content: ANATOMIST_PERSONA + '\n\n' + KOSHA_GRAMMAR + '\n\n' + DYADIC_LOOP },
-        { role: 'user', content: compositePrompt(cfgA.subject, cfgB.subject, synthA, synthB, crossResonance) },
-      ],
-      max_tokens: 8192, temperature: 0.5, timeout_ms: 300_000,
-    });
-    composite = res.content;
-    await writeFile(compositeCachePath, composite);
-    console.log(`    ✓ ${res.latency_ms}ms · ${res.completion_tokens}tk · ${composite.length} chars`);
-  }
-  const wordCount = composite.split(/\s+/).filter(Boolean).length;
-  console.log(`  ✓ Composite synthesis: ${wordCount.toLocaleString()} words`);
-
-  // Build composite-resonance SVG from docx-hardened mahadasha (NOT Selemene)
-  const sharedAk = cfgA.atmakaraka && cfgB.atmakaraka && cfgA.atmakaraka.toLowerCase() === cfgB.atmakaraka.toLowerCase()
-    ? cfgA.atmakaraka : undefined;
-  const compositeSvg = renderCompositeResonance({
-    subject_a: cfgA.subject,
-    subject_b: cfgB.subject,
-    a_mahadasha: cfgA.mahadasha ? {
-      current: cfgA.mahadasha.current_lord,
-      next: cfgA.mahadasha.next_lord,
-      transition_iso: cfgA.mahadasha.current_ends_iso,
-    } : undefined,
-    b_mahadasha: cfgB.mahadasha ? {
-      current: cfgB.mahadasha.current_lord,
-      next: cfgB.mahadasha.next_lord,
-      transition_iso: cfgB.mahadasha.current_ends_iso,
-    } : undefined,
-    electromagnetic_channels: ['24-61 Awareness', '32-54 Transformation', '28-38 Struggle'],
-    companionship_gates: ['31', '62', '42', '46', '52'],
-    shared_atmakaraka: sharedAk,
-  }, { width: 640 });
-
-  const kundaliA = renderKundaliChart({
-    lagna: cfgA.lagna,
-    placements: cfgA.placements,
-    atmakaraka: cfgA.atmakaraka,
-    subject_name: cfgA.subject,
-  }, { width: 400 });
-  const kundaliB = renderKundaliChart({
-    lagna: cfgB.lagna,
-    placements: cfgB.placements,
-    atmakaraka: cfgB.atmakaraka,
-    subject_name: cfgB.subject,
-  }, { width: 400 });
-
-  // Assemble composite body — opening + sections + composite SVG + dual Kundalis
-  let body = '';
-  const sections = composite.split(/\n## /);
-  body += `<section class="opening">${mdToHtml(sections[0] || '')}</section>`;
-  for (let i = 1; i < sections.length; i++) {
-    body += `<section>${mdToHtml('## ' + sections[i])}</section>`;
-    if (i === 1) {
-      body += renderViz('The Composite Field', compositeSvg,
-        'Two charts in resonance. The luminous threads between the arcs name the electromagnetic channels you make as a pair that neither chart has alone. The paired pivots mark the simultaneous Mahadasha transitions.');
-      body += `<div style="display:flex;gap:20px;margin:32px 0;page-break-inside:avoid;">
-        <figure class="viz" style="flex:1;margin:0;"><div class="viz-title">${cfgA.subject} · Rashi</div>${kundaliA}</figure>
-        <figure class="viz" style="flex:1;margin:0;"><div class="viz-title">${cfgB.subject} · Rashi</div>${kundaliB}</figure>
-      </div>`;
-    }
-  }
-
-  const html = renderHTMLPage({
-    title: `Composite Field — ${cfgA.subject} × ${cfgB.subject}`,
-    cover: {
-      subject: `${cfgA.subject} × ${cfgB.subject}`,
-      birth_date: '',
-      cover_mandala_svg: compositeSvg,
-    },
-    body,
-    is_composite: true,
-    composite_subject_a: cfgA.subject,
-    composite_subject_b: cfgB.subject,
-  });
-
-  const htmlPath = join(outputDir, `${dyadSlug}-composite.html`);
-  await writeFile(htmlPath, html);
-  console.log(`  ✓ HTML → ${basename(htmlPath)} (${(html.length / 1024).toFixed(1)} KB)`);
-
-  const pdfPath = htmlPath.replace(/\.html$/, '.pdf');
-  if (exportPDF(htmlPath, pdfPath)) {
-    console.log(`  ✓ PDF  → ${basename(pdfPath)}`);
-  }
-
-  console.log('\n═══ COMPOSITE COMPLETE ═══');
-  console.log(`  Word count: ${wordCount.toLocaleString()}`);
-}
-
-main().catch((err) => { console.error('FATAL:', err); process.exit(1); });
+const proc = spawn('node', args, { stdio: 'inherit' });
+proc.on('exit', (code) => process.exit(code ?? 1));
+proc.on('error', (err) => { console.error('Failed to spawn orchestrator:', err); process.exit(1); });

--- a/scripts/integratedreading-mode.ts
+++ b/scripts/integratedreading-mode.ts
@@ -1,0 +1,635 @@
+#!/usr/bin/env node --import tsx
+// ─── /integratedreading — Unified Mode Orchestrator ────────────────────
+// Single runner for all reading modes: composite-dyad, composite-triad,
+// partner-synastry, business-partners, family-penta, team-synergy.
+//
+// Mode-specific knowledge lives in scripts/integratedreading/modes/<mode>.md
+// (per docs/plans/2026-05-14-reading-modes-design.md § Section 1).
+//
+// CLI:
+//   node --import tsx scripts/integratedreading-mode.ts \
+//     --mode <name> \
+//     --subjects-dir <path>         # contains 01_*.json, 02_*.json, ... (lexical order)
+//     --output-dir <path>
+//     [--use-cache]                 # reuse most recent prior .runs/ subdir
+//     [--skip-solos]                # don't auto-chain solo synthesis
+//     [--dry-run]                   # parse + validate + print plan, no API calls
+//
+// Closes #38 (P1.1).
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join, basename, dirname, resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+import { homedir } from 'node:os';
+
+import { parseModeDoc, summarizeLessons, type ParsedModeDoc, type PassSpec } from './integratedreading/modes/parser.js';
+import { renderByTopology } from './integratedreading/render/svg/index.js';
+import {
+  ANATOMIST_PERSONA,
+  KOSHA_GRAMMAR,
+  DYADIC_LOOP,
+} from './integratedreading/system-prompts.js';
+import { NvidiaClient } from './integratedreading/nvidia-client.js';
+import {
+  SYNTH_MODELS,
+  findOrCreateCachedRunDir,
+  countCrossRefs,
+} from './autoresearch-integratedreading/defaults.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// CLI parsing
+// ────────────────────────────────────────────────────────────────────────
+
+interface CliArgs {
+  mode: string;
+  subjectsDir: string;
+  outputDir: string;
+  useCache: boolean;
+  skipSolos: boolean;
+  dryRun: boolean;
+}
+
+function parseArgs(argv: string[]): CliArgs {
+  const getFlag = (name: string): string | undefined => {
+    const idx = argv.indexOf(`--${name}`);
+    if (idx >= 0 && idx + 1 < argv.length) return argv[idx + 1];
+    return undefined;
+  };
+  const hasFlag = (name: string): boolean => argv.includes(`--${name}`);
+
+  const mode = getFlag('mode');
+  const subjectsDir = getFlag('subjects-dir');
+  const outputDir = getFlag('output-dir');
+
+  if (!mode || !subjectsDir || !outputDir) {
+    console.error('Usage: integratedreading-mode.ts --mode <name> --subjects-dir <path> --output-dir <path> [--use-cache] [--skip-solos] [--dry-run]');
+    process.exit(1);
+  }
+
+  return {
+    mode,
+    subjectsDir: resolve(subjectsDir),
+    outputDir: resolve(outputDir),
+    useCache: hasFlag('use-cache'),
+    skipSolos: hasFlag('skip-solos'),
+    dryRun: hasFlag('dry-run'),
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Subject loading
+// ────────────────────────────────────────────────────────────────────────
+
+interface SubjectConfig {
+  subject: string;
+  birth_date?: string;
+  birth_time?: string;
+  birth_place?: string;
+  latitude?: number;
+  longitude?: number;
+  timezone?: string;
+  lagna?: string;
+  atmakaraka?: string;
+  placements?: any[];
+  mahadasha?: {
+    current_lord?: string;
+    current_ends_iso?: string;
+    next_lord?: string;
+    next_starts_iso?: string;
+    next_duration_years?: number;
+  };
+  output_dir?: string;
+  source_path?: string;
+  [key: string]: any;
+}
+
+function loadSubjects(subjectsDir: string): SubjectConfig[] {
+  if (!existsSync(subjectsDir)) {
+    throw new Error(`Subjects directory not found: ${subjectsDir}`);
+  }
+  const files = readdirSync(subjectsDir)
+    .filter((f) => /^\d+_.+\.json$/.test(f))
+    .sort();   // lexical → ordinal positions
+
+  if (files.length === 0) {
+    throw new Error(`No subject configs in ${subjectsDir}. Expected files matching 01_*.json, 02_*.json, ...`);
+  }
+
+  return files.map((f) => {
+    const path = join(subjectsDir, f);
+    const cfg = JSON.parse(readFileSync(path, 'utf-8')) as SubjectConfig;
+    if (!cfg.subject) {
+      throw new Error(`${path}: missing required field 'subject'`);
+    }
+    return cfg;
+  });
+}
+
+function slugify(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '');
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Solo synthesis lookup + auto-chain
+// ────────────────────────────────────────────────────────────────────────
+
+function findExistingSolo(subjectOutputDir: string | undefined, slug: string): string | undefined {
+  if (!subjectOutputDir) return undefined;
+  const runsRoot = join(subjectOutputDir, '.runs');
+  if (!existsSync(runsRoot)) return undefined;
+  const candidates = readdirSync(runsRoot)
+    .filter((d) => /^\d{4}-/.test(d))
+    .sort()
+    .reverse();
+  for (const d of candidates) {
+    const path = join(runsRoot, d, `06_synthesis_${slug}.md`);
+    if (existsSync(path)) return path;
+  }
+  return undefined;
+}
+
+interface SoloRun {
+  subject: string;
+  slug: string;
+  synthesisPath: string;
+  synthesis: string;
+}
+
+async function chainSolo(cfg: SubjectConfig, cfgFilePath: string): Promise<void> {
+  return new Promise((res, rej) => {
+    const proc = spawn('node', [
+      '--import', 'tsx',
+      join(dirname(new URL(import.meta.url).pathname), 'integratedreading-full.ts'),
+      cfgFilePath,
+    ], { stdio: 'inherit' });
+    proc.on('exit', (code) => {
+      if (code === 0) res();
+      else rej(new Error(`integratedreading-full.ts exited with code ${code} for subject ${cfg.subject}`));
+    });
+    proc.on('error', rej);
+  });
+}
+
+async function ensureSolos(
+  subjects: SubjectConfig[],
+  subjectsDir: string,
+  skipSolos: boolean,
+): Promise<SoloRun[]> {
+  const slugs = subjects.map((s) => slugify(s.subject));
+  // Locate existing
+  const existing: Array<SoloRun | undefined> = subjects.map((cfg, i) => {
+    const path = findExistingSolo(cfg.output_dir, slugs[i]);
+    if (!path) return undefined;
+    return {
+      subject: cfg.subject,
+      slug: slugs[i],
+      synthesisPath: path,
+      synthesis: readFileSync(path, 'utf-8'),
+    };
+  });
+
+  const missing = subjects.filter((_, i) => !existing[i]);
+  if (missing.length > 0) {
+    if (skipSolos) {
+      const names = missing.map((m) => m.subject).join(', ');
+      throw new Error(`--skip-solos but missing solos for: ${names}`);
+    }
+    console.log(`  → chaining ${missing.length} missing solo(s) in parallel: ${missing.map((m) => m.subject).join(', ')}`);
+    // For each missing subject, derive its cfg file path from the subjects directory
+    const filesInDir = readdirSync(subjectsDir).filter((f) => /^\d+_.+\.json$/.test(f)).sort();
+    await Promise.all(missing.map((cfg) => {
+      const i = subjects.indexOf(cfg);
+      const cfgFilePath = join(subjectsDir, filesInDir[i]);
+      return chainSolo(cfg, cfgFilePath);
+    }));
+    // Re-scan after spawn completes
+    for (let i = 0; i < subjects.length; i++) {
+      if (existing[i]) continue;
+      const path = findExistingSolo(subjects[i].output_dir, slugs[i]);
+      if (!path) throw new Error(`Solo synthesis still missing for ${subjects[i].subject} after chaining`);
+      existing[i] = {
+        subject: subjects[i].subject,
+        slug: slugs[i],
+        synthesisPath: path,
+        synthesis: readFileSync(path, 'utf-8'),
+      };
+    }
+  }
+
+  return existing as SoloRun[];
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Interpolation
+// ────────────────────────────────────────────────────────────────────────
+
+interface InterpolationContext {
+  subject_names: string;
+  subject_roster: string;
+  prior_pass: string;
+  lessons_summary: string;
+  overlay_summary: string;
+  bridge_mandates: string;
+  pass_title: string;
+  target_words: string;
+}
+
+function buildOverlaySummary(doc: ParsedModeDoc): string {
+  const ews = doc.frontmatter.engine_overlay_weights;
+  const foreground = Object.entries(ews).filter(([, w]) => w > 1).sort(([, a], [, b]) => b - a);
+  const background = Object.entries(ews).filter(([, w]) => w < 1).sort(([, a], [, b]) => a - b);
+  const foreText = foreground.length > 0
+    ? `Foreground engines (weight > 1.0): ${foreground.map(([k, w]) => `${k} ${w}`).join(', ')}.`
+    : '';
+  const backText = background.length > 0
+    ? `Background engines (weight < 1.0): ${background.map(([k, w]) => `${k} ${w}`).join(', ')}.`
+    : '';
+  const houseText = `House overlay: ${doc.frontmatter.house_overlay.join(', ')}.`;
+  return [foreText, backText, houseText].filter(Boolean).join(' ');
+}
+
+function buildBridgeMandates(doc: ParsedModeDoc): string {
+  return doc.frontmatter.bridge_mandates.map((m, i) => `${i + 1}. ${m}`).join('\n');
+}
+
+function interpolate(template: string, ctx: InterpolationContext): string {
+  let out = template;
+  for (const [key, value] of Object.entries(ctx)) {
+    out = out.replace(new RegExp(`\\{\\{${key}\\}\\}`, 'g'), value);
+  }
+  return out;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// LLM API key
+// ────────────────────────────────────────────────────────────────────────
+
+function loadNvidiaKey(): string {
+  if (process.env.NVIDIA_API_KEY) return process.env.NVIDIA_API_KEY;
+  const envPath = join(homedir(), '.claude', '.env');
+  if (existsSync(envPath)) {
+    const m = readFileSync(envPath, 'utf-8').match(/^NVIDIA_API_KEY=(\S+)/m);
+    if (m) { process.env.NVIDIA_API_KEY = m[1]; return m[1]; }
+  }
+  throw new Error('NVIDIA_API_KEY not found (env or ~/.claude/.env)');
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Pass execution
+// ────────────────────────────────────────────────────────────────────────
+
+interface PassResult {
+  pass: PassSpec;
+  content: string;
+  words: number;
+  xrefs: number;
+  latency_ms: number;
+  model: string;
+}
+
+async function executePass(
+  client: NvidiaClient,
+  pass: PassSpec,
+  doc: ParsedModeDoc,
+  ctx: InterpolationContext,
+  soloRuns: SoloRun[],
+): Promise<PassResult> {
+  const template = doc.sections[pass.template];
+  if (!template) throw new Error(`Pass ${pass.id}: template section '${pass.template}' not found`);
+
+  const userPrompt = interpolate(template, {
+    ...ctx,
+    pass_title: pass.title,
+    target_words: String(pass.target_words),
+  });
+
+  // Prepend the solo syntheses as context for the first pass; subsequent passes
+  // rely on prior_pass + lessons_summary instead (to avoid blowing the context window).
+  const soloContext = ctx.prior_pass === ''
+    ? '\n\n## SOURCE SOLO SYNTHESES (input data — do not echo back verbatim, synthesize)\n\n' +
+      soloRuns.map((s) => `### ${s.subject.toUpperCase()}\n${s.synthesis.slice(0, 14000)}`).join('\n\n')
+    : '';
+
+  const system = `${ANATOMIST_PERSONA}\n\n${KOSHA_GRAMMAR}\n\n${DYADIC_LOOP}\n\n` +
+    (ctx.lessons_summary ? `${ctx.lessons_summary}\n\n` : '') +
+    `## Mode Overlay Rules\n\n${ctx.overlay_summary}\n\n## Bridge Mandates\n\n${ctx.bridge_mandates}`;
+
+  const model = pass.model ?? SYNTH_MODELS.PRIMARY;
+  const result = await client.callWithRetry({
+    model,
+    messages: [
+      { role: 'system', content: system },
+      { role: 'user', content: userPrompt + soloContext },
+    ],
+    max_tokens: 8192,
+    temperature: 0.5,
+    timeout_ms: 360_000,
+  }, 1);
+
+  const content = result.content;
+  const words = content.split(/\s+/).filter(Boolean).length;
+  const xrefs = countCrossRefs(content).total;
+
+  return {
+    pass,
+    content,
+    words,
+    xrefs,
+    latency_ms: result.latency_ms,
+    model,
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Linear vs hierarchical execution
+// ────────────────────────────────────────────────────────────────────────
+
+async function runLinear(
+  client: NvidiaClient,
+  doc: ParsedModeDoc,
+  baseCtx: Omit<InterpolationContext, 'prior_pass' | 'pass_title' | 'target_words'>,
+  soloRuns: SoloRun[],
+  runDir: string,
+): Promise<PassResult[]> {
+  const results: PassResult[] = [];
+  let assembled = '';
+  for (const pass of doc.frontmatter.pass_plan) {
+    const cachePath = join(runDir, `pass_${pass.id}.md`);
+    if (existsSync(cachePath)) {
+      const cached = readFileSync(cachePath, 'utf-8');
+      const words = cached.split(/\s+/).filter(Boolean).length;
+      const xrefs = countCrossRefs(cached).total;
+      console.log(`    ✓ Pass ${pass.id} cached: ${words}w · ${xrefs} xrefs`);
+      results.push({ pass, content: cached, words, xrefs, latency_ms: 0, model: pass.model ?? SYNTH_MODELS.PRIMARY });
+      assembled += '\n\n' + cached;
+      continue;
+    }
+    console.log(`    → Pass ${pass.id} (${pass.title})…`);
+    const ctx: InterpolationContext = {
+      ...baseCtx,
+      prior_pass: assembled.slice(-4000),
+      pass_title: pass.title,
+      target_words: String(pass.target_words),
+    };
+    const result = await executePass(client, pass, doc, ctx, soloRuns);
+    await writeFile(cachePath, result.content);
+    console.log(`      ${result.latency_ms}ms · ${result.words}w · ${result.xrefs} xrefs (target ${pass.target_words}w, model ${result.model})`);
+    results.push(result);
+    assembled += '\n\n' + result.content;
+  }
+  return results;
+}
+
+async function runHierarchical(
+  client: NvidiaClient,
+  doc: ParsedModeDoc,
+  baseCtx: Omit<InterpolationContext, 'prior_pass' | 'pass_title' | 'target_words'>,
+  soloRuns: SoloRun[],
+  runDir: string,
+): Promise<PassResult[]> {
+  // Hierarchical: first pass is outline; subsequent passes carry it forward.
+  const [outlinePass, ...expansions] = doc.frontmatter.pass_plan;
+  const outlineCachePath = join(runDir, `pass_${outlinePass.id}.md`);
+  let outlineContent: string;
+  let outlineResult: PassResult;
+  if (existsSync(outlineCachePath)) {
+    outlineContent = readFileSync(outlineCachePath, 'utf-8');
+    const words = outlineContent.split(/\s+/).filter(Boolean).length;
+    const xrefs = countCrossRefs(outlineContent).total;
+    console.log(`    ✓ Outline cached: ${words}w · ${xrefs} xrefs`);
+    outlineResult = { pass: outlinePass, content: outlineContent, words, xrefs, latency_ms: 0, model: outlinePass.model ?? SYNTH_MODELS.PRIMARY };
+  } else {
+    console.log(`    → Outline pass (${outlinePass.title})…`);
+    const ctx: InterpolationContext = {
+      ...baseCtx,
+      prior_pass: '',
+      pass_title: outlinePass.title,
+      target_words: String(outlinePass.target_words),
+    };
+    outlineResult = await executePass(client, outlinePass, doc, ctx, soloRuns);
+    outlineContent = outlineResult.content;
+    await writeFile(outlineCachePath, outlineContent);
+    console.log(`      ${outlineResult.latency_ms}ms · ${outlineResult.words}w · ${outlineResult.xrefs} xrefs`);
+  }
+
+  const results: PassResult[] = [outlineResult];
+  let assembled = outlineContent;
+  for (const pass of expansions) {
+    const cachePath = join(runDir, `pass_${pass.id}.md`);
+    if (existsSync(cachePath)) {
+      const cached = readFileSync(cachePath, 'utf-8');
+      const words = cached.split(/\s+/).filter(Boolean).length;
+      const xrefs = countCrossRefs(cached).total;
+      console.log(`    ✓ Pass ${pass.id} cached: ${words}w · ${xrefs} xrefs`);
+      results.push({ pass, content: cached, words, xrefs, latency_ms: 0, model: pass.model ?? SYNTH_MODELS.PRIMARY });
+      assembled += '\n\n' + cached;
+      continue;
+    }
+    console.log(`    → Pass ${pass.id} (${pass.title})…`);
+    // Expansion passes always carry the outline + their prior expansion
+    const priorWithOutline =
+      `## OUTLINE (anchor reference for this expansion)\n\n${outlineContent}\n\n## PRIOR EXPANSION PASSES\n\n${assembled.slice(-3500)}`;
+    const ctx: InterpolationContext = {
+      ...baseCtx,
+      prior_pass: priorWithOutline,
+      pass_title: pass.title,
+      target_words: String(pass.target_words),
+    };
+    const result = await executePass(client, pass, doc, ctx, soloRuns);
+    await writeFile(cachePath, result.content);
+    console.log(`      ${result.latency_ms}ms · ${result.words}w · ${result.xrefs} xrefs (target ${pass.target_words}w)`);
+    results.push(result);
+    assembled += '\n\n' + result.content;
+  }
+  return results;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Render + assemble final output
+// ────────────────────────────────────────────────────────────────────────
+
+interface AssembledReport {
+  markdown: string;
+  total_words: number;
+  total_xrefs: number;
+  total_latency_ms: number;
+  pass_metrics: Array<{ id: string; title: string; words: number; xrefs: number; target_words: number; latency_ms: number; model: string }>;
+}
+
+function assemble(passes: PassResult[]): AssembledReport {
+  const markdown = passes.map((p) => p.content.trim()).join('\n\n---\n\n');
+  return {
+    markdown,
+    total_words: passes.reduce((sum, p) => sum + p.words, 0),
+    total_xrefs: passes.reduce((sum, p) => sum + p.xrefs, 0),
+    total_latency_ms: passes.reduce((sum, p) => sum + p.latency_ms, 0),
+    pass_metrics: passes.map((p) => ({
+      id: p.pass.id,
+      title: p.pass.title,
+      words: p.words,
+      xrefs: p.xrefs,
+      target_words: p.pass.target_words,
+      latency_ms: p.latency_ms,
+      model: p.model,
+    })),
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Main
+// ────────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  // ─── Load mode doc ────────────────────────────────────────────────
+  const modeDocPath = resolve(
+    new URL(import.meta.url).pathname,
+    '..',
+    'integratedreading/modes',
+    `${args.mode}.md`,
+  );
+  if (!existsSync(modeDocPath)) {
+    throw new Error(`Mode doc not found: ${modeDocPath}\nAvailable modes: ${listAvailableModes().join(', ')}`);
+  }
+  const doc = parseModeDoc(modeDocPath);
+  console.log('═══ integratedreading-mode ═══');
+  console.log(`  Mode:        ${doc.frontmatter.mode}`);
+  console.log(`  Architecture: ${doc.frontmatter.architecture}`);
+  console.log(`  Topology:    ${doc.frontmatter.svg_topology}`);
+  console.log(`  Passes:      ${doc.frontmatter.pass_plan.length}`);
+  console.log(`  Target:      ${doc.frontmatter.target_words.min}–${doc.frontmatter.target_words.max} words`);
+
+  // ─── Load subjects ────────────────────────────────────────────────
+  const subjects = loadSubjects(args.subjectsDir);
+  const sc = doc.frontmatter.subject_count;
+  if (subjects.length < sc.min || subjects.length > sc.max) {
+    throw new Error(`Mode '${args.mode}' requires ${sc.min === sc.max ? sc.min : `${sc.min}-${sc.max}`} subjects; found ${subjects.length}`);
+  }
+  console.log(`  Subjects:    ${subjects.map((s) => s.subject).join(' × ')}`);
+
+  if (args.dryRun) {
+    console.log('\n[DRY RUN — exit before any API calls]');
+    process.exit(0);
+  }
+
+  // ─── Run directory (cache-aware) ──────────────────────────────────
+  await mkdir(args.outputDir, { recursive: true });
+  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+  const runSlug = slugify(`${doc.frontmatter.mode}-${subjects.map((s) => slugify(s.subject)).join('-x-')}`);
+  const { runDir, reusedPrior } = findOrCreateCachedRunDir({
+    outputDir: args.outputDir,
+    freshTs: ts,
+    useCache: args.useCache,
+    cacheFileName: `${runSlug}.md`,
+  });
+  if (reusedPrior) console.log(`  ↻ Reusing prior run dir for --use-cache`);
+  console.log(`  Run dir:     ${runDir}`);
+
+  // ─── Auto-chain missing solos ────────────────────────────────────
+  console.log(`\n→ Phase: solo synthesis acquisition`);
+  const soloRuns = await ensureSolos(subjects, args.subjectsDir, args.skipSolos);
+  console.log(`  ✓ ${soloRuns.length} solo syntheses loaded`);
+
+  // ─── Pass execution ──────────────────────────────────────────────
+  console.log(`\n→ Phase: ${doc.frontmatter.architecture} multi-pass synthesis`);
+  const client = new NvidiaClient(loadNvidiaKey());
+  const baseCtx: Omit<InterpolationContext, 'prior_pass' | 'pass_title' | 'target_words'> = {
+    subject_names: subjects.map((s) => s.subject).join(', '),
+    subject_roster: subjects.map((s, i) => `${i + 1}. ${s.subject}${s.lagna ? ` — ${s.lagna} Lagna` : ''}${s.atmakaraka ? `, AK ${s.atmakaraka}` : ''}`).join('\n'),
+    lessons_summary: summarizeLessons(doc.lessons),
+    overlay_summary: buildOverlaySummary(doc),
+    bridge_mandates: buildBridgeMandates(doc),
+  };
+
+  const passes = doc.frontmatter.architecture === 'hierarchical'
+    ? await runHierarchical(client, doc, baseCtx, soloRuns, runDir)
+    : await runLinear(client, doc, baseCtx, soloRuns, runDir);
+
+  // ─── Assemble + render ───────────────────────────────────────────
+  const report = assemble(passes);
+  const assembledPath = join(runDir, `${runSlug}.md`);
+  await writeFile(assembledPath, report.markdown);
+  console.log(`\n✓ Assembled: ${assembledPath} (${report.total_words.toLocaleString()} words · ${report.total_xrefs} cross-refs)`);
+
+  // Metric report
+  const metricPath = join(runDir, `metrics_${runSlug}.json`);
+  await writeFile(metricPath, JSON.stringify(report, null, 2));
+  console.log(`✓ Metrics:   ${metricPath}`);
+
+  // SVG (just verify dispatch works — full HTML render lands in P2)
+  try {
+    const topology = doc.frontmatter.svg_topology;
+    if (topology === 'dyad-arc' && subjects.length === 2) {
+      const svg = renderByTopology(topology, buildDyadSvgData(subjects), { width: 640 });
+      await writeFile(join(runDir, `${runSlug}.svg`), svg);
+      console.log(`✓ SVG:       ${runSlug}.svg (dyad-arc)`);
+    } else if (topology === 'triad-triangle' && subjects.length === 3) {
+      const svg = renderByTopology(topology, buildTriadSvgData(subjects), { width: 720 });
+      await writeFile(join(runDir, `${runSlug}.svg`), svg);
+      console.log(`✓ SVG:       ${runSlug}.svg (triad-triangle)`);
+    } else {
+      console.log(`  (SVG topology '${topology}' renders in P2 interactive HTML phase — skipping standalone export)`);
+    }
+  } catch (err: any) {
+    console.warn(`  ⚠ SVG render skipped: ${err.message}`);
+  }
+
+  // ─── Summary ─────────────────────────────────────────────────────
+  console.log('\n═══ summary ═══');
+  console.log(`  Total words: ${report.total_words.toLocaleString()} (target ${doc.frontmatter.target_words.min}-${doc.frontmatter.target_words.max})`);
+  console.log(`  Cross-refs:  ${report.total_xrefs}`);
+  console.log(`  Latency:     ${(report.total_latency_ms / 1000).toFixed(0)}s total`);
+  for (const m of report.pass_metrics) {
+    const hit = m.words >= m.target_words * 0.8 ? '✓' : '⚠';
+    console.log(`    ${hit} Pass ${m.id}: ${m.words}w / ${m.target_words}w target · ${m.xrefs} xrefs`);
+  }
+}
+
+function listAvailableModes(): string[] {
+  const modesDir = resolve(new URL(import.meta.url).pathname, '..', 'integratedreading/modes');
+  if (!existsSync(modesDir)) return [];
+  return readdirSync(modesDir)
+    .filter((f) => f.endsWith('.md') && !f.startsWith('_'))
+    .map((f) => f.replace(/\.md$/, ''));
+}
+
+// SVG data builders — minimal shape needed by existing renderers
+function buildDyadSvgData(subjects: SubjectConfig[]) {
+  const [a, b] = subjects;
+  return {
+    subject_a: a.subject,
+    subject_b: b.subject,
+    a_mahadasha: a.mahadasha ? {
+      current: a.mahadasha.current_lord || '',
+      next: a.mahadasha.next_lord || '',
+      transition_iso: a.mahadasha.current_ends_iso,
+    } : undefined,
+    b_mahadasha: b.mahadasha ? {
+      current: b.mahadasha.current_lord || '',
+      next: b.mahadasha.next_lord || '',
+      transition_iso: b.mahadasha.current_ends_iso,
+    } : undefined,
+    shared_atmakaraka: a.atmakaraka && b.atmakaraka && a.atmakaraka === b.atmakaraka ? a.atmakaraka : undefined,
+  };
+}
+
+function buildTriadSvgData(subjects: SubjectConfig[]) {
+  const colors = ['#10B5A7', '#0B50FB', '#C5A017'];   // emerald, indigo, gold
+  return {
+    subjects: subjects.map((s, i) => ({
+      name: s.subject,
+      arc_color: colors[i % colors.length],
+      current_mahadasha_lord: s.mahadasha?.current_lord,
+      next_mahadasha_lord: s.mahadasha?.next_lord,
+      next_mahadasha_iso: s.mahadasha?.current_ends_iso,
+    })),
+    shared_keys: [],
+  };
+}
+
+main().catch((err) => {
+  console.error('\nFATAL:', err.message);
+  process.exit(1);
+});

--- a/scripts/integratedreading-triad.ts
+++ b/scripts/integratedreading-triad.ts
@@ -1,301 +1,67 @@
-// ─── /integratedreading — Triad Synastry (3-subject composite) ──────
-// Takes three completed solo readings and produces a 5500-7000 word
-// triadic composite reading + HTML/PDF with the triad-resonance SVG.
+#!/usr/bin/env node --import tsx
+// ─── /integratedreading — Composite Triad (LEGACY SHIM) ────────────────
 //
-// Usage:
-//   node --import tsx scripts/integratedreading-triad.ts \
-//     --subject-a <a-cfg.json> \
-//     --subject-b <b-cfg.json> \
-//     --subject-c <c-cfg.json> \
-//     --output-dir <dir>
-//     [--use-cache]
+// This file is a thin compatibility shim. The canonical implementation now
+// lives in `scripts/integratedreading-mode.ts` driven by the mode doc at
+// `scripts/integratedreading/modes/composite-triad.md`.
+//
+// The shim translates legacy CLI flags (--subject-a / --subject-b /
+// --subject-c / --output-dir / --use-cache) into the new orchestrator's
+// contract (--mode composite-triad / --subjects-dir / --output-dir /
+// --use-cache) by materializing a temporary subjects-directory.
+//
+// Preserves CI / external workflows that still invoke this filename
+// directly. New work should call `integratedreading-mode.ts` directly.
+//
+// Closes #41 (P1.4) — triad half.
 
-import { readFile, writeFile, mkdir } from 'node:fs/promises';
-import { existsSync, readFileSync, readdirSync } from 'node:fs';
-import { join, resolve, basename } from 'node:path';
-import { execSync } from 'node:child_process';
-import { homedir } from 'node:os';
-import { findOrCreateCachedRunDir } from './autoresearch-integratedreading/defaults.js';
+import { mkdtempSync, copyFileSync, existsSync } from 'node:fs';
+import { join, resolve, basename, dirname } from 'node:path';
+import { spawn } from 'node:child_process';
+import { tmpdir } from 'node:os';
 
-import { NvidiaClient, MODELS } from './integratedreading/nvidia-client.js';
-import {
-  ANATOMIST_PERSONA,
-  KOSHA_GRAMMAR,
-  DYADIC_LOOP,
-  triadCompositePrompt,
-} from './integratedreading/system-prompts.js';
-import {
-  renderHTMLPage, renderViz, renderVizPlate, renderVizTrio,
-  renderFigIndex, createFigureRegistry,
-} from './integratedreading/render/templates.js';
-import { renderCompositeTriad } from './integratedreading/render/svg/composite-triad.js';
-import { renderKundaliChart } from './integratedreading/render/svg/kundali-chart.js';
-import { BRAND } from './integratedreading/render/styles.js';
-
-// ──────────────────────────────────────────────────────────────────────
-
-interface SubjectConfig {
-  source_path?: string;
-  subject: string;
-  birth_date: string;
-  birth_time?: string;
-  birth_place?: string;
-  lagna: string;
-  atmakaraka?: string;
-  placements: any[];
-  mahadasha?: {
-    current_lord: string;
-    current_ends_iso?: string;
-    next_lord: string;
-    next_starts_iso?: string;
-    next_duration_years?: number;
-  };
-  output_dir: string;
-}
-
-function getArg(name: string, fallback?: string): string | undefined {
+function getArg(name: string): string | undefined {
   const idx = process.argv.indexOf(`--${name}`);
   if (idx > 0 && idx + 1 < process.argv.length) return process.argv[idx + 1];
-  return fallback;
-}
-function hasFlag(name: string): boolean { return process.argv.includes(`--${name}`); }
-
-function loadNvidiaKey(): string {
-  if (process.env.NVIDIA_API_KEY) return process.env.NVIDIA_API_KEY;
-  const envPath = join(homedir(), '.claude', '.env');
-  if (existsSync(envPath)) {
-    const m = readFileSync(envPath, 'utf-8').match(/^NVIDIA_API_KEY=(\S+)/m);
-    if (m) { process.env.NVIDIA_API_KEY = m[1]; return m[1]; }
-  }
-  throw new Error('NVIDIA_API_KEY not found in env');
-}
-
-function mdToHtml(md: string): string {
-  if (!md.trim()) return '';
-  try {
-    return execSync('pandoc -f markdown -t html5 --syntax-highlighting=none', { input: md, encoding: 'utf-8' });
-  } catch { return md.split(/\n\n+/).map((p) => `<p>${p}</p>`).join('\n'); }
-}
-
-function findLatestRun(outputDir: string, slug: string): string | undefined {
-  const runsRoot = join(outputDir, '.runs');
-  if (!existsSync(runsRoot)) return undefined;
-  const dirs = readdirSync(runsRoot).filter((d) => /^\d{4}-/.test(d)).sort().reverse();
-  for (const d of dirs) {
-    const synthPath = join(runsRoot, d, `06_synthesis_${slug}.md`);
-    if (existsSync(synthPath)) return join(runsRoot, d);
-  }
   return undefined;
 }
-
-function slugify(s: string): string {
-  return s.toLowerCase().replace(/[^a-z0-9]/g, '-').replace(/-+/g, '-');
+function hasFlag(name: string): boolean {
+  return process.argv.includes(`--${name}`);
 }
 
-const CHROME_BIN = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
-function exportPDF(htmlPath: string, pdfPath: string): boolean {
-  if (!existsSync(CHROME_BIN)) return false;
-  try {
-    execSync(`"${CHROME_BIN}" --headless --disable-gpu --no-pdf-header-footer --print-to-pdf-no-header --print-to-pdf="${pdfPath}" --virtual-time-budget=10000 --hide-scrollbars "file://${htmlPath}"`,
-      { stdio: 'pipe', timeout: 90_000 });
-    return existsSync(pdfPath);
-  } catch (err: any) {
-    console.warn(`  ⚠ PDF: ${err.message.slice(0, 100)}`);
-    return false;
-  }
+const subjectA = getArg('subject-a');
+const subjectB = getArg('subject-b');
+const subjectC = getArg('subject-c');
+const outputDir = getArg('output-dir');
+const useCache = hasFlag('use-cache');
+
+if (!subjectA || !subjectB || !subjectC || !outputDir) {
+  console.error('Usage: integratedreading-triad.ts --subject-a <cfg.json> --subject-b <cfg.json> --subject-c <cfg.json> --output-dir <dir> [--use-cache]');
+  console.error('');
+  console.error('NOTE: This is a deprecation shim. Prefer:');
+  console.error('  integratedreading-mode.ts --mode composite-triad --subjects-dir <dir> --output-dir <dir>');
+  process.exit(1);
 }
 
-// ──────────────────────────────────────────────────────────────────────
-
-async function main() {
-  const configA = getArg('subject-a');
-  const configB = getArg('subject-b');
-  const configC = getArg('subject-c');
-  const outputDir = getArg('output-dir') || '/tmp/triad-output';
-  const useCache = hasFlag('use-cache');
-  if (!configA || !configB || !configC) {
-    console.error('Usage: integratedreading-triad.ts --subject-a <cfg> --subject-b <cfg> --subject-c <cfg> --output-dir <dir>');
-    process.exit(1);
-  }
-
-  const cfgA: SubjectConfig = JSON.parse(await readFile(configA, 'utf-8'));
-  const cfgB: SubjectConfig = JSON.parse(await readFile(configB, 'utf-8'));
-  const cfgC: SubjectConfig = JSON.parse(await readFile(configC, 'utf-8'));
-  const slugA = slugify(cfgA.subject);
-  const slugB = slugify(cfgB.subject);
-  const slugC = slugify(cfgC.subject);
-  const triadSlug = `${slugA}-x-${slugB}-x-${slugC}`;
-
-  await mkdir(outputDir, { recursive: true });
-  const ts = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
-  // Cache-aware run-dir: shared helper. Reuses prior run that has the
-  // triad cache file present; otherwise creates a fresh ts dir.
-  const { runDir, reusedPrior } = findOrCreateCachedRunDir({
-    outputDir,
-    freshTs: ts,
-    useCache,
-    cacheFileName: `08_triad_${triadSlug}.md`,
-  });
-  if (reusedPrior) console.log(`  ↻ Reusing prior run dir for --use-cache`);
-
-  console.log('═══ integratedreading-triad ═══');
-  console.log(`  A: ${cfgA.subject}`);
-  console.log(`  B: ${cfgB.subject}`);
-  console.log(`  C: ${cfgC.subject}`);
-  console.log(`  Output: ${outputDir}`);
-
-  // Load all three solo syntheses
-  const runDirA = findLatestRun(cfgA.output_dir, slugA);
-  const runDirB = findLatestRun(cfgB.output_dir, slugB);
-  const runDirC = findLatestRun(cfgC.output_dir, slugC);
-  if (!runDirA || !runDirB || !runDirC) {
-    console.error(`FATAL: Need all 3 solo readings completed first.`);
-    console.error(`  A: ${runDirA || '(missing)'}`);
-    console.error(`  B: ${runDirB || '(missing)'}`);
-    console.error(`  C: ${runDirC || '(missing)'}`);
-    process.exit(1);
-  }
-  const synthA = await readFile(join(runDirA, `06_synthesis_${slugA}.md`), 'utf-8');
-  const synthB = await readFile(join(runDirB, `06_synthesis_${slugB}.md`), 'utf-8');
-  const synthC = await readFile(join(runDirC, `06_synthesis_${slugC}.md`), 'utf-8');
-  console.log(`  ✓ A synthesis (${synthA.split(/\s+/).length.toLocaleString()} words)`);
-  console.log(`  ✓ B synthesis (${synthB.split(/\s+/).length.toLocaleString()} words)`);
-  console.log(`  ✓ C synthesis (${synthC.split(/\s+/).length.toLocaleString()} words)`);
-
-  // Cross-resonance — derived from docx-hardened values
-  const akA = cfgA.atmakaraka?.toLowerCase();
-  const akB = cfgB.atmakaraka?.toLowerCase();
-  const akC = cfgC.atmakaraka?.toLowerCase();
-  const sharedAks: string[] = [];
-  if (akA === akB && akA) sharedAks.push(`${cfgA.subject} × ${cfgB.subject}: shared Atmakaraka ${akA}`);
-  if (akA === akC && akA) sharedAks.push(`${cfgA.subject} × ${cfgC.subject}: shared Atmakaraka ${akA}`);
-  if (akB === akC && akB) sharedAks.push(`${cfgB.subject} × ${cfgC.subject}: shared Atmakaraka ${akB}`);
-
-  const crossResonance = {
-    subjects: [cfgA.subject, cfgB.subject, cfgC.subject],
-    atmakarakas: { [cfgA.subject]: cfgA.atmakaraka, [cfgB.subject]: cfgB.atmakaraka, [cfgC.subject]: cfgC.atmakaraka },
-    shared_atmakaraka_pairs: sharedAks,
-    mahadasha_pivots: [
-      cfgA.mahadasha ? { subject: cfgA.subject, current: cfgA.mahadasha.current_lord, next: cfgA.mahadasha.next_lord, pivot_iso: cfgA.mahadasha.current_ends_iso } : null,
-      cfgB.mahadasha ? { subject: cfgB.subject, current: cfgB.mahadasha.current_lord, next: cfgB.mahadasha.next_lord, pivot_iso: cfgB.mahadasha.current_ends_iso } : null,
-      cfgC.mahadasha ? { subject: cfgC.subject, current: cfgC.mahadasha.current_lord, next: cfgC.mahadasha.next_lord, pivot_iso: cfgC.mahadasha.current_ends_iso } : null,
-    ].filter(Boolean),
-    lagnas: { [cfgA.subject]: cfgA.lagna, [cfgB.subject]: cfgB.lagna, [cfgC.subject]: cfgC.lagna },
-  };
-
-  // Run triad composite synthesis
-  const triadCachePath = join(runDir, `08_triad_${triadSlug}.md`);
-  let triadSynthesis: string;
-  if (useCache && existsSync(triadCachePath)) {
-    triadSynthesis = await readFile(triadCachePath, 'utf-8');
-    console.log(`  ✓ Triad cached`);
-  } else {
-    console.log(`  → Triad composite synthesis (gpt-oss-120b, single deep pass)...`);
-    const nvidia = new NvidiaClient(loadNvidiaKey());
-    const res = await nvidia.callWithRetry({
-      model: MODELS.GPT_OSS_120B,
-      messages: [
-        { role: 'system', content: ANATOMIST_PERSONA + '\n\n' + KOSHA_GRAMMAR + '\n\n' + DYADIC_LOOP },
-        { role: 'user', content: triadCompositePrompt(cfgA.subject, cfgB.subject, cfgC.subject, synthA, synthB, synthC, crossResonance) },
-      ],
-      max_tokens: 8192, temperature: 0.5, timeout_ms: 360_000,
-    });
-    triadSynthesis = res.content;
-    await writeFile(triadCachePath, triadSynthesis);
-    console.log(`    ✓ ${res.latency_ms}ms · ${res.completion_tokens}tk · ${triadSynthesis.length} chars`);
-  }
-  const wordCount = triadSynthesis.split(/\s+/).filter(Boolean).length;
-  console.log(`  ✓ Triad synthesis: ${wordCount.toLocaleString()} words`);
-
-  // Build triad-resonance SVG
-  const subjects: any[] = [
-    {
-      name: cfgA.subject,
-      arc_color: BRAND.coherenceEmerald,
-      current_mahadasha_lord: cfgA.mahadasha?.current_lord,
-      next_mahadasha_lord: cfgA.mahadasha?.next_lord,
-      next_mahadasha_iso: cfgA.mahadasha?.current_ends_iso,
-    },
-    {
-      name: cfgB.subject,
-      arc_color: BRAND.flowIndigo,
-      current_mahadasha_lord: cfgB.mahadasha?.current_lord,
-      next_mahadasha_lord: cfgB.mahadasha?.next_lord,
-      next_mahadasha_iso: cfgB.mahadasha?.current_ends_iso,
-    },
-    {
-      name: cfgC.subject,
-      arc_color: BRAND.sacredGold,
-      current_mahadasha_lord: cfgC.mahadasha?.current_lord,
-      next_mahadasha_lord: cfgC.mahadasha?.next_lord,
-      next_mahadasha_iso: cfgC.mahadasha?.current_ends_iso,
-    },
-  ];
-  const sharedKeys = sharedAks.length > 0
-    ? sharedAks.map((s) => s.split(': shared ')[1])
-    : ['Wheel of Fortune × Emperor × Hermit'];   // placeholder if no AK matches
-  const triadSvg = renderCompositeTriad({
-    subjects: subjects as any,
-    shared_keys: sharedKeys,
-  }, { width: 720 });
-
-  // Three Kundali charts side-by-side
-  const kA = renderKundaliChart({ lagna: cfgA.lagna, placements: cfgA.placements, atmakaraka: cfgA.atmakaraka, subject_name: cfgA.subject }, { width: 340 });
-  const kB = renderKundaliChart({ lagna: cfgB.lagna, placements: cfgB.placements, atmakaraka: cfgB.atmakaraka, subject_name: cfgB.subject }, { width: 340 });
-  const kC = renderKundaliChart({ lagna: cfgC.lagna, placements: cfgC.placements, atmakaraka: cfgC.atmakaraka, subject_name: cfgC.subject }, { width: 340 });
-
-  // Assemble HTML body
-  const figs = createFigureRegistry();
-  let body = '';
-  const sections = triadSynthesis.split(/\n## /);
-  body += `<section class="opening">${mdToHtml(sections[0] || '')}</section>`;
-  for (let i = 1; i < sections.length; i++) {
-    body += `<section>${mdToHtml('## ' + sections[i])}</section>`;
-    if (i === 1) {
-      const tField = 'The Triadic Resonance Field';
-      body += renderVizPlate({
-        figNo: figs.next(tField),
-        title: tField,
-        svg: triadSvg,
-        caption: 'Three bodies in a single archetypal triangle. Each subject occupies one vertex of the field; the gold threads name the pair-resonances. The center seed is the joint operative — what the three are structurally configured to author together.',
-        attribution: 'Source: Selemene triad layer · DOCX-hardened pivots',
-      });
-      body += renderVizTrio(
-        { figNo: figs.next(`${cfgA.subject} · Rashi`), title: `${cfgA.subject} · Rashi`, svg: kA,
-          caption: `Lagna: ${cfgA.lagna}${cfgA.atmakaraka ? ' · AK: ' + cfgA.atmakaraka : ''}` },
-        { figNo: figs.next(`${cfgB.subject} · Rashi`), title: `${cfgB.subject} · Rashi`, svg: kB,
-          caption: `Lagna: ${cfgB.lagna}${cfgB.atmakaraka ? ' · AK: ' + cfgB.atmakaraka : ''}` },
-        { figNo: figs.next(`${cfgC.subject} · Rashi`), title: `${cfgC.subject} · Rashi`, svg: kC,
-          caption: `Lagna: ${cfgC.lagna}${cfgC.atmakaraka ? ' · AK: ' + cfgC.atmakaraka : ''}` },
-      );
-    }
-  }
-
-  const html = renderHTMLPage({
-    title: `Composite Triad — ${cfgA.subject} × ${cfgB.subject} × ${cfgC.subject}`,
-    cover: {
-      subject: `${cfgA.subject} × ${cfgB.subject} × ${cfgC.subject}`,
-      birth_date: '',
-      cover_mandala_svg: triadSvg,
-    },
-    body,
-    fig_index_html: renderFigIndex(figs.list()),
-    is_composite: true,
-    composite_subject_a: cfgA.subject,
-    composite_subject_b: `${cfgB.subject} × ${cfgC.subject}`,
-  });
-
-  const htmlPath = join(outputDir, `${triadSlug}-triad.html`);
-  await writeFile(htmlPath, html);
-  console.log(`  ✓ HTML → ${basename(htmlPath)} (${(html.length / 1024).toFixed(1)} KB)`);
-
-  const pdfPath = htmlPath.replace(/\.html$/, '.pdf');
-  if (exportPDF(htmlPath, pdfPath)) {
-    console.log(`  ✓ PDF  → ${basename(pdfPath)}`);
-  }
-
-  console.log('\n═══ TRIAD COMPLETE ═══');
-  console.log(`  Word count: ${wordCount.toLocaleString()} (target 5500-7000)`);
+for (const [name, path] of [['Subject A', subjectA], ['Subject B', subjectB], ['Subject C', subjectC]] as const) {
+  if (!existsSync(path)) { console.error(`${name} config not found: ${path}`); process.exit(1); }
 }
 
-main().catch((err) => { console.error('FATAL:', err); process.exit(1); });
+console.warn('[deprecation] integratedreading-triad.ts is a shim — prefer integratedreading-mode.ts --mode composite-triad');
+
+const subjectsDir = mkdtempSync(join(tmpdir(), 'composite-triad-subjects-'));
+copyFileSync(resolve(subjectA), join(subjectsDir, '01_' + basename(subjectA)));
+copyFileSync(resolve(subjectB), join(subjectsDir, '02_' + basename(subjectB)));
+copyFileSync(resolve(subjectC), join(subjectsDir, '03_' + basename(subjectC)));
+
+const orchestratorPath = join(dirname(new URL(import.meta.url).pathname), 'integratedreading-mode.ts');
+const args = ['--import', 'tsx', orchestratorPath,
+  '--mode', 'composite-triad',
+  '--subjects-dir', subjectsDir,
+  '--output-dir', resolve(outputDir),
+];
+if (useCache) args.push('--use-cache');
+
+const proc = spawn('node', args, { stdio: 'inherit' });
+proc.on('exit', (code) => process.exit(code ?? 1));
+proc.on('error', (err) => { console.error('Failed to spawn orchestrator:', err); process.exit(1); });

--- a/scripts/integratedreading/modes/composite-dyad.md
+++ b/scripts/integratedreading/modes/composite-dyad.md
@@ -1,0 +1,310 @@
+---
+mode: composite-dyad
+subject_count:
+  min: 2
+  max: 2
+roles:
+  - subject-A
+  - subject-B
+target_words:
+  min: 12000
+  max: 15000
+architecture: linear
+pass_plan:
+  - id: alpha
+    title: "The Composite Field — Identity + Vedic"
+    target_words: 3200
+    template: pass-alpha-template
+  - id: beta
+    title: "Human Design, Gene Keys, and the Coherence Event"
+    target_words: 3600
+    template: pass-beta-template
+  - id: gamma
+    title: "Marriage Already-Already + Joint Career & Dharma"
+    target_words: 3400
+    template: pass-gamma-template
+  - id: delta
+    title: "Joint Health, Anti-Dependency, Final Synthesis"
+    target_words: 3000
+    template: pass-delta-template
+engine_overlay_weights:
+  vimshottari: 1.5
+  human-design: 1.5
+  gene-keys: 1.5
+  tarot: 1.5
+  panchanga: 1.0
+  transits: 1.0
+  i-ching: 1.0
+  nadabrahman: 0.7
+  biorhythm: 0.5
+  face-reading: 0.3
+  sigil-forge: 0.3
+house_overlay: [7, 1, 4, 11, 2, 5, 10, 12]
+bridge_mandates:
+  - "Each major claim must surface from at least two chart layers (Vedic × HD, Vedic × Gene Keys, HD × Tarot, etc.) — never single-system."
+  - "The Mahadasha pivot stagger between the two subjects must be treated as PHASE-LOCK GEOMETRY, not coincidence."
+  - "Anti-dependency milestones in Pass δ must be PER-KOSHA-LAYER and ANATOMICALLY GROUNDED (no biohack metrics, no generic spiritual phrasing)."
+svg_topology: dyad-arc
+---
+
+## pass-alpha-template
+
+You are running Pass α of the 4-pass composite-dyad synthesis. This pass establishes the **composite field's identity layer + Vedic foundation** for {{subject_names}}.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+{{prior_pass}}
+
+---
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES FOR THIS PASS
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+# Composite Reading — {{subject_names}}
+
+## Opening — Why This Reading Treats Two Charts as One Field
+*(2-3 paragraphs. Frame the dyad as the reading **instrument**, not the reading **subject**. Two bodies, two breath-currents, two pattern-engines weaving a single composite field. Tsarion three-world grammar (Eigenwelt / Mitwelt / Umwelt) operates at all three resolutions across both charts. Aletheios + Pichet dyad braid throughout — not "Aletheios reads chart A, Pichet reads chart B" but both pillars active for both subjects.)*
+
+## Part I — The Composite Field Identity
+
+### 1.1 The Joint Identity Stack
+*(Table: 6 rows × 2 subject columns — Sun condition, Moon condition, Lagna + Lagna-lord, Atmakaraka, Vocation indicator, Spouse indicator (Darakaraka or 7th-lord). Each cell anatomically + archetypally grounded — not just "Cancer Sun" but "Cancer Sun in Ashlesha — the right liver-zone carries the constriction").*
+
+### 1.2 What Both Charts Agree On — The Bedrock
+*(5-7 bullet themes that recur across both. Each one must be: anatomically grounded (where in the body it lives) + archetypally named (which Tarot arcanum or Gene Key codon it carries) + timeline-anchored (which dasha period brings it forward). No generic spiritual phrasing.)*
+
+### 1.3 Where The Charts Diverge — The Texture
+*(3-5 bullet differences. Divergence is the **point** — what each subject brings that the other doesn't have alone. The composite is generative because of these gaps, not despite them.)*
+
+## Part II — The Vedic Composite
+
+### 2.1 Cross-Chart Mutual Disposition (Graha Custody)
+*(Which graha in chart A custodies which graha in chart B, and vice versa. This is where the field actually lives — when subject A's Jupiter sits in the sign owned by subject B's Mars, the dyad has a Jupiter-Mars couplet operating at the chart level that neither has alone. Walk through every mutual disposition that's structurally meaningful.)*
+
+### 2.2 The Atmakaraka × Spouse-Significator Coupling
+*(Subject A's Atmakaraka × Subject B's Darakaraka, and vice versa. Is the sovereignty-significator of one the spouse-significator of the other? This is the Cl(3) Vijnanamaya layer's deepest cross-coupling.)*
+
+### 2.3 Pancha Bhuta as a Pair
+*(Table: Element | Subject A count | Subject B count | Pair total. Then narrate: where the pair has element coverage neither has alone; where the pair has element OVER-concentration that creates somatic pressure; where the pair is missing an element that the field will need to source externally.)*
+
+### 2.4 Composite Lagna Lord — Bridge Graha or Imbalance Vector?
+*(Compute the composite Lagna (midpoint of the two Lagnas, or the rasi the pair operates from when functioning as one field). Identify its lord. Is that graha well-disposed in BOTH charts? If yes, the bridge is functional. If it's strong in one and afflicted in the other, the field has a structural asymmetry to name.)*
+
+End Pass α here. Pass β will continue with Human Design + Gene Keys + the Mahadasha coherence event.
+
+## pass-beta-template
+
+You are running Pass β of the 4-pass composite-dyad synthesis for {{subject_names}}. Pass α has established the identity layer + Vedic composite.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+## PRIOR PASS OUTPUT (carry voice + cross-references forward)
+{{prior_pass}}
+
+---
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part III — The Human Design Composite
+
+### 3.1 Combined Center Definition
+*(Which of the 9 centers go online ONLY when the pair is together. The defined-undefined cross-completion. This is the HD's vital-layer (Pranamaya / Cl(1)) signature of the dyad — what one's open center the other defines, and what that means somatically.)*
+
+### 3.2 Electromagnetic Channels
+*(The channels created when one subject has half a channel defined and the other has the other half. These are NOT in either chart alone — they only exist in the pair. Name each one: Channel number, gates involved, what it does operationally. Tie each channel to where it lives in the body and which Vedic placement co-signs it.)*
+
+### 3.3 Companionship Gates
+*(Gates both subjects share. These are the resonance baseline — where the pair is already in sync, doesn't have to be built, only honored.)*
+
+### 3.4 Cross-Strategy Compatibility
+*(Manifestor × Generator vs Projector × MG vs etc. How each strategy interacts with the other. Where the pair's HD-types create natural complementarity, and where they create friction that needs articulation.)*
+
+## Part IV — Gene Keys + Tarot Composite
+
+### 4.1 Pearl-to-Pearl Coupling
+*(Subject A's Pearl × Subject B's Pearl. What the two prosperity-sphere codons compose into when held together. The Pearl is the framework's prosperity-currency — what the pair generates that's economically real.)*
+
+### 4.2 Joint Major Arcana Stack
+*(The combined Tarot keys both subjects carry — Atmakaraka-derived Tarot, Lagna-derived Tarot, Sun-derived Tarot. Name the joint stack. What archetypal current does the dyad carry through the Mitwelt (cultural-archetypal) layer? "The Hermit × The Empress operating together makes ____.")*
+
+### 4.3 Shared Gene-Key Themes
+*(Which spheres/codons both subjects activate. Where the genetic-archetypal current of the dyad lives.)*
+
+## Part V — The Mahadasha Coherence Event
+
+### 5.1 What Both Sides Are Closing
+*(For each subject, name the current Mahadasha lord and what its shadow has been. What is being **completed** as this MD ends?)*
+
+### 5.2 What Both Sides Are Opening
+*(For each subject, name the next Mahadasha lord and what its grace-current carries. What is being **inaugurated**?)*
+
+### 5.3 The Phase-Lock Stagger
+*(This is THE keystone of this Pass. Compute the day-gap between the two pivot dates. NAME IT: "The X-day stagger between [Subject A]'s [closing-MD]→[next-MD] pivot on [date] and [Subject B]'s [closing-MD]→[next-MD] pivot on [date]." Then decode what the stagger means structurally — why does the field open this one BEFORE that one? What does that say about which subject leads which transition? This is phase-lock geometry; treat it as data, not coincidence.)*
+
+### 5.4 The Sade Sati Stagger (if applicable) — Built-in Load Balancing
+*(If one subject is in Sade Sati while the other is not, the field has natural load-balancing: one carries Saturn's compression while the other carries movement. Name it. If neither is in Sade Sati or both are, name that instead.)*
+
+### 5.5 Joint Operating Window Year-by-Year (next 5-8 years)
+*(For each year of the next 5-8: which antardasha is each subject in, what that intersection produces, what's structurally possible in that year that wasn't in the prior, what's structurally NOT possible. This is the joint operational calendar.)*
+
+End Pass β here. Pass γ will pivot to the Marriage frame + Joint Career.
+
+## pass-gamma-template
+
+You are running Pass γ of the 4-pass composite-dyad synthesis for {{subject_names}}. Passes α-β have established the identity layer + Vedic composite + HD + Gene Keys + Mahadasha event.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+---
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part VI — The Marriage Already-Already
+
+*(Direct address: marriage at the chart-architectural layer is structurally complete or it isn't. Engage the chart-evidence honestly. Don't assert; **decode**.)*
+
+### 6.1 The Five-Layer Confirmation
+*(Walk through each Kosha layer (the body / the breath / the pattern engine / the discerner / the imperishable seed) and ask: at this layer, is the pair structurally married? What's the chart-evidence?)*
+
+### 6.2 What Public Ritual Is and Isn't
+*(Public ritual confirms an existing structural reality, or it inaugurates one that doesn't exist yet. Which is this pair's case? The chart will say.)*
+
+### 6.3 What Children / Property / Ventures Are
+*(Artifacts of the matrix, not constituents of it. The pair generates these because the field is operative — not the other way around. Name what the pair is structurally configured to produce.)*
+
+## Part VII — Joint Career & Dharma
+
+### 7.1 What the Dyad Authors at World-Scale (the 16-Year Mature Artifact)
+*(The new Mahadasha cycle for each subject lasts 16-20 years. By 2042-ish, what visible artifact in the world should this pair have produced? Anchor it in the Atmakaraka cross-coupling + HD electromagnetic channels + joint Tarot stack.)*
+
+### 7.2 Cross-Domain Coupling — Subject A's Work × Subject B's Work
+*(Identify each subject's primary dharma signature (10th house lord, Atmakaraka in vocational house, Saturn placement). Then decode the COMPOSITE: when one's domain feeds the other's, what does the pair build? When they're tangential, what does each enable the other to do?)*
+
+### 7.3 The Operating Cadence — Vision × Operations × Execution
+*(In any joint operative, someone holds vision (Jupiter signal), someone holds operations (Saturn signal), someone executes (Mars signal). For this pair, who carries which signal? Be specific — point to the actual planetary placements.)*
+
+End Pass γ here. Pass δ will close with Health + Anti-Dependency + Final Synthesis.
+
+## pass-delta-template
+
+You are running Pass δ — the keystone closing pass — of the 4-pass composite-dyad synthesis for {{subject_names}}.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+This pass carries the framework's design principle: success = decreasing reliance on the interpreter. Anti-dependency is the telos. Do not produce remedies, products, or prescriptions. Produce **self-decoding capacity milestones**.
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+---
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part VIII — Joint Health & Practices
+
+### 8.1 Joint Pranic Phase-Lock
+*(How the two breath-rhythms interact. Where the pair regulates each other's pranic state. Anatomically: which axis does each subject's breath stabilize for the other?)*
+
+### 8.2 Practices the Dyad Runs Better Than Either Alone
+*(Specific practices the chart-architecture supports as a pair — meditation pair-config, ritual pair-config, work-rhythm pair-config. Name 3-5. Each one tied to a chart placement that signals it.)*
+
+## Part IX — Anti-Dependency for the Dyad
+
+### 9.1 Joint Self-Decoding Milestones — 2027 / 2030 / 2042
+*(For each milestone year, per Kosha layer, what should this pair be able to do **without consulting the chart, the agent, or any external reader**? Be operationally specific. Examples (not exhaustive — derive yours from the chart):*
+
+*— 2027 (MD + 1 yr): the pair can read each other's pranic state in real time without external cueing.*
+*— 2030 (MD ~25%): the pair interprets joint dasha transitions for themselves.*
+*— 2042 (MD complete): the joint AKSHARA artifact has matured into a visible thing in the world.*
+
+*Do this for each Kosha layer, not just "the body". Each milestone is anatomically grounded and timeline-anchored.)*
+
+## Part X — Final Synthesis
+
+### 10.1 The Single Sentence
+*(The pair in ONE sentence. Not a tagline — a structural identity claim that the rest of the reading has earned.)*
+
+### 10.2 The Joint AKSHARA Artifact
+*(What the dyad writes into the world over the 16-20 year arc. The imperishable seed (Anandamaya / Cl(7)) of the JOINT operative. Be specific about its mature form.)*
+
+### 10.3 What To Avoid — Joint Anti-Patterns
+*(3-5 specific patterns this pair must NOT default into. Tied to chart-architecture (where the field has built-in vulnerability).)*
+
+### 10.4 What To Strongly Pursue — Joint Dharma
+*(3-5 specific moves this pair should make. Tied to chart-architecture (where the field has built-in opening).)*
+
+### 10.5 The One Practice That Ties Both Charts Together
+*(The single practice that, if held faithfully across the next 16-20 years, will let the pair become unable to need the reading.)*
+
+End Pass δ. The full 4-pass composite-dyad reading is now complete.
+
+## overlay-rules
+
+For composite-dyad mode, the overlays foreground the systems that carry pair-level resonance: Vimshottari (the dasha-stagger phase-lock), Human Design (electromagnetic channels), Gene Keys (Pearl coupling), Tarot (joint Major Arcana stack). House 7 (partnership) is the primary cross-overlay, with houses 1 (self / Lagna), 4 (root field), 11 (joint operative + community), 2 (joint resources), 5 (creative offspring including ventures), 10 (joint dharma signature), and 12 (the imperishable / lineage current) as supporting overlays.
+
+Engines weighted < 1.0 (panchanga, transits, nadabrahman, biorhythm, face-reading, sigil-forge) operate as background — present but not foregrounded unless they specifically carry pair-signal.
+
+## glossary
+
+- **Phase-lock geometry** — the structural relationship between the two subjects' Mahadasha pivots. The day-count stagger encodes who-leads-whom in the field's transition.
+- **AKSHARA coupling** — the imperishable-seed coupling at Anandamaya / Cl(7). When both subjects' AKSHARA seeds resonate at the same archetypal frequency, the dyad has a joint imperishable artifact to produce.
+- **The composite is the instrument** — the reading is **of** the composite field, **through** the Aletheios+Pichet dyad pillars. The composite is the subject, the dyad is the lens.
+- **Marriage already-already** — the framing that marriage is a structural fact at the chart-architectural layer, not a public-ritual event. Public ritual confirms; it does not constitute.
+
+## interactions
+
+*(For Phase 2 interactive HTML output — placeholder until P2 lands.)*
+
+- **Hover a resonance thread** in the dyad-arc SVG → tooltip names the four-way cross-system bridge it carries (Vedic-house × Tarot × HD-channel × dasha-anchor).
+- **Scroll-scrub the dasha-stagger timeline** → animates the day-count window from Pivot A to Pivot B.
+- **Click the AKSHARA-coupling glyph** in the center seed → expands the Joint AKSHARA Artifact section.
+
+## lessons
+
+*(No autoresearch passes yet. First Pass 6 entry will land here per autoresearch contract.)*

--- a/scripts/integratedreading/modes/composite-triad.md
+++ b/scripts/integratedreading/modes/composite-triad.md
@@ -1,0 +1,299 @@
+---
+mode: composite-triad
+subject_count:
+  min: 3
+  max: 3
+roles:
+  - subject-A
+  - subject-B
+  - subject-C
+target_words:
+  min: 12000
+  max: 15000
+architecture: linear
+pass_plan:
+  - id: alpha
+    title: "The Triadic Field — Identity + Three-Way Bedrock"
+    target_words: 3200
+    template: pass-alpha-template
+  - id: beta
+    title: "The Vedic Triangle + Human Design Triangle"
+    target_words: 3600
+    template: pass-beta-template
+  - id: gamma
+    title: "Gene Keys / Tarot Triangle + Three-Way Mahadasha Field"
+    target_words: 3600
+    template: pass-gamma-template
+  - id: delta
+    title: "Triadic Operative + Anti-Dependency + Final Synthesis"
+    target_words: 2800
+    template: pass-delta-template
+engine_overlay_weights:
+  vimshottari: 1.7
+  human-design: 1.5
+  gene-keys: 1.5
+  tarot: 1.5
+  panchanga: 1.0
+  transits: 1.0
+  i-ching: 1.0
+  nadabrahman: 0.7
+  biorhythm: 0.5
+  face-reading: 0.3
+  sigil-forge: 0.3
+house_overlay: [7, 1, 4, 11, 2, 5, 10, 3]
+bridge_mandates:
+  - "For every claim about the triad, name which PAIR (A-B, A-C, or B-C) carries it AND what the third subject provides to make it triadic."
+  - "All three Mahadasha pivots must be plotted relative to each other — the triad has a 3-way stagger, not 3 unrelated transitions."
+  - "Anti-dependency in Pass δ must address what each subject becomes unable to need from the OTHER TWO across the new dasha cycle."
+svg_topology: triad-triangle
+---
+
+## pass-alpha-template
+
+You are running Pass α of the 4-pass composite-triad synthesis for {{subject_names}}.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+A triad is **not** three dyads stacked. It's a single archetypal triangle where each pair carries shared current AND the third subject provides what the pair alone doesn't generate. Hold that geometry throughout.
+
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+# Composite Triad — {{subject_names}}
+
+## Opening — Why Three Charts as One Field
+*(2-3 paragraphs. Frame the triad: three bodies, three breath-currents, three pattern-engines weaving a single archetypal current through three-world grammar (Eigenwelt / Mitwelt / Umwelt) at three resolutions. The dyad (Aletheios + Pichet) operates as the reading INSTRUMENT for all three subjects simultaneously — not "one dyad per subject" but ONE dyad witnessing three.)*
+
+## Part I — The Triadic Identity Field
+
+### 1.1 The Three-Body Joint Identity Stack
+*(Table: 6 rows × 3 subject columns — Sun condition, Moon condition, Lagna + Lagna-lord, Atmakaraka, Vocation indicator, Spouse/Partnership indicator. Each cell anatomically grounded.)*
+
+### 1.2 What All Three Charts Agree On — The Bedrock
+*(5-7 bullet themes that recur across ALL THREE. Each one: anatomically grounded + archetypally named + timeline-anchored. The bedrock is what's true regardless of which pair you're foregrounding.)*
+
+### 1.3 Pair-Bedrock — What Each Pair Shares (and the Third Provides)
+*(Three sub-paragraphs, one per pair:*
+
+*— **A-B pair** shares X (what the third subject C contributes to make this triadic)*
+*— **A-C pair** shares Y (what the third subject B contributes to make this triadic)*
+*— **B-C pair** shares Z (what the third subject A contributes to make this triadic)*
+
+*This is the heart of triadic geometry. Each pair has resonance lines + the third subject completes the geometry.)*
+
+### 1.4 Three-Way Tensions — The Texture
+*(2-3 bullet contradictions in the triad. Where the field has friction that needs articulation. Triads are dynamic precisely BECAUSE they have built-in friction at one vertex.)*
+
+End Pass α here. Pass β will move into Vedic + HD triangles.
+
+## pass-beta-template
+
+You are running Pass β of the composite-triad synthesis for {{subject_names}}. Pass α has established the triadic identity field.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part II — The Vedic Triangle
+
+### 2.1 Cross-Chart Mutual Disposition Across the Triad
+*(Which graha in chart A is custodied by which planet in chart B, in chart C, and vice versa for all three pairs. The triangle of grah-custody is the Vedic skeleton of the field.)*
+
+### 2.2 The Atmakaraka Triangle
+*(How the three souls' significators relate. Do any two share an Atmakaraka? Do all three carry different ones? What's the **operative** Atmakaraka of the triad as a whole — the graha that, when foregrounded, brings all three subjects into resonant action?)*
+
+### 2.3 Combined Pancha Bhuta — Three-Body Element Coverage
+*(Table: Element | Subject A | Subject B | Subject C | Triad Total | Triad Coverage Score. Then narrate: where the triad has element coverage NEITHER pair has alone; where the triad concentrates; where the triad has a missing element that must be sourced externally.)*
+
+### 2.4 Three-Way Darakaraka / Partnership Cross-Matches
+*(Subject A's Darakaraka against Subject B's and C's chart positions, etc. Is the triad a closed partnership ring (each carries the other's spouse-significator)? Or a partial ring (only some pairs match)? Or three independent significators with no cross-coupling?)*
+
+### 2.5 Composite Triad Lagna Lord
+*(Compute the operative Lagna of the triad — the rasi the three subjects operate from when functioning as one field. Identify its lord. Is it strong in all three charts? In two? In one? This determines the triad's structural stability.)*
+
+## Part III — The Human Design Triangle
+
+### 3.1 Combined Center Definition Across All Three Charts
+*(How many of 9 centers go online when all three subjects are present together. Which centers go online ONLY in triad-config, not in any pair?)*
+
+### 3.2 Electromagnetic Channels Within the Triad
+*(Pair-by-pair channel completions. Where does the pair A-B make a channel that A-C and B-C don't? Which channels does the triad complete that NO pair makes alone?)*
+
+### 3.3 Companionship Gates Across All Three
+*(Gates all three subjects share. These are the resonance baseline — where the triad is already in sync.)*
+
+### 3.4 Cross-Strategy Compatibility
+*(Mix of Generator / Projector / MG / Manifestor across the three. How each strategy interacts. Where the triad's HD-types compose into natural role-cluster, and where they require conscious bridging.)*
+
+End Pass β. Pass γ will move into Gene Keys / Tarot triangles + the Mahadasha three-way field.
+
+## pass-gamma-template
+
+You are running Pass γ of the composite-triad synthesis for {{subject_names}}. Passes α-β have established identity + Vedic + HD triangles.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part IV — Gene Keys + Tarot Triangle
+
+### 4.1 Pearl-to-Pearl Triangle
+*(Three Pearls. What they compose into as a triangle. The Pearl is the prosperity codon — what the triad generates as economic / generative current when held together.)*
+
+### 4.2 The Triad's Joint Major Arcana Stack
+*(Tarot keys for each subject (Atmakaraka-derived, Lagna-derived, Sun-derived) — then the joint stack across all three. What archetypal current does the triad carry through the cultural-archetypal (Mitwelt) layer? "The Hermit × The Empress × The Magician operating together makes ____.")*
+
+### 4.3 Shared Gene-Key Themes Across the Triad
+*(Which spheres / codons two or more of the three subjects activate. Where the triad's genetic-archetypal current carries coherent signal.)*
+
+### 4.4 The Codon Ring of the Triad
+*(If the three subjects together activate a coherent codon ring — name it. If not, name which segment of a ring they hold and which segments are missing.)*
+
+## Part V — The Mahadasha Three-Way Field
+
+### 5.1 Each Subject's Closing Mahadasha
+*(For each of three subjects, name the current MD lord and what its shadow has been.)*
+
+### 5.2 Each Subject's Opening Mahadasha
+*(For each, name the next MD lord and what grace-current it carries.)*
+
+### 5.3 The Three-Way Stagger
+*(THE keystone of this Pass. Compute the day-gap between all three pivots:*
+
+*— A→A_next on [date]*
+*— B→B_next on [date]*
+*— C→C_next on [date]*
+
+*Plot them on a single timeline. NAME the geometry: who leads, who follows, who anchors. The triad has a structural ordering encoded in its dasha-pivot sequence. Decode what that ordering means — why does the field open one transition first? What does that say about which subject's grace-cycle initiates the triad's joint operative? This is three-way phase-lock geometry; treat it as data.)*
+
+### 5.4 Joint Operating Calendar — Next 5-8 Years Year-by-Year
+*(For each year of the next 5-8: which antardasha is each subject in. The 3-way intersection. What's structurally possible in that year, what's structurally NOT possible. This is the triad's operational calendar.)*
+
+End Pass γ. Pass δ will close with the triadic operative + anti-dependency + final synthesis.
+
+## pass-delta-template
+
+You are running Pass δ — the keystone closing pass — of the composite-triad synthesis for {{subject_names}}.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+This pass carries the framework's design principle: success = decreasing reliance on the interpreter. Anti-dependency is the telos. No remedies, no products, no prescriptions. **Self-decoding capacity milestones** only.
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part VI — The Triadic Operative
+
+### 6.1 What the Triad Authors at World-Scale (16-Year Mature Artifact)
+*(By the time the longest dasha cycle matures (~16-20 years out), what visible artifact in the world should this triad have produced? Anchor in the Atmakaraka triangle + joint Tarot stack + HD electromagnetic channels.)*
+
+### 6.2 Role-Cluster Within the Triad
+*(In any joint operative, three structural roles emerge: Vision (Jupiter signal), Operations (Saturn signal), Execution (Mars signal). For this triad, which subject carries which signal? Be specific — point to actual placements. If a role is unclaimed by any of the three, name that as a structural gap.)*
+
+### 6.3 Cross-Domain Coupling
+*(Subject A's primary dharma × Subject B's × Subject C's. How they couple. Where the triad has natural cross-pollination, and where it has tangential domains that require conscious bridging.)*
+
+## Part VII — Anti-Dependency for the Triad
+
+### 7.1 Triadic Self-Decoding Milestones — 2027 / 2030 / 2042
+*(For each milestone year, per Kosha layer, what should each of the three subjects be able to do **without consulting the other two, the chart, the agent, or any external reader**? Be operationally specific. The triad's anti-dependency telos is each member becoming unable to need the field — which is the same as the field becoming structurally complete enough to disperse without losing what it was.)*
+
+### 7.2 What Each Pair Becomes Unable to Need
+*(Three sub-paragraphs: A-B pair stops needing X; A-C stops needing Y; B-C stops needing Z. The dispersal of pair-level dependence is part of the triad's maturation.)*
+
+## Part VIII — Final Synthesis
+
+### 8.1 The Single Sentence
+*(The triad in ONE sentence. A structural identity claim the reading has earned.)*
+
+### 8.2 The Joint AKSHARA Artifact
+*(What the triad writes into the world. The imperishable seed (Anandamaya / Cl(7)) of the triadic operative. Its mature form.)*
+
+### 8.3 Three Things to Avoid
+*(One per pair: A-B anti-pattern, A-C anti-pattern, B-C anti-pattern. Each tied to chart-architecture.)*
+
+### 8.4 Three Things to Pursue
+*(One per pair, each tied to chart-architecture.)*
+
+### 8.5 The One Practice That Ties All Three Together
+*(The single practice that, if held faithfully across the next 16-20 years, will let the triad become unable to need the reading.)*
+
+End Pass δ. The full 4-pass composite-triad reading is complete.
+
+## overlay-rules
+
+For composite-triad mode, Vimshottari is the most foregrounded engine (the 3-way dasha stagger is the field's operational skeleton). HD and Gene Keys carry the structural-identity overlays. Tarot carries the archetypal-cultural overlay. House 7 (partnership) remains primary; house 3 (the third — siblings, cohort, peer-network) is the structural-third overlay specific to triads.
+
+Engines weighted < 1.0 operate as background — present but not foregrounded unless they carry triad-specific signal (e.g., panchanga for the day-of-pivot reading).
+
+## glossary
+
+- **Three-way phase-lock geometry** — the structural ordering of the three Mahadasha pivots. Who leads, who follows, who anchors. The triad has a built-in temporal sequence encoded in its dasha pivots.
+- **The triad is not three dyads** — three dyads stacked is a different geometry than a triangle. Triangle = each pair carries shared current + the third subject provides what the pair alone doesn't generate. Hold this throughout.
+- **Codon ring of the triad** — when the three subjects' Gene Keys activate consecutive codons in a ring, the triad carries a coherent genetic-archetypal current that no pair carries alone.
+- **The dispersal is part of the maturation** — anti-dependency in a triad means each pair becoming unable to need the others. The field matures by structurally completing its own dispersal.
+
+## interactions
+
+*(For Phase 2 interactive HTML output — placeholder until P2 lands.)*
+
+- **Hover a pair-thread** in the triad-triangle SVG → tooltip names which pair carries which resonance.
+- **Click any vertex** → that subject's contribution to the triadic field auto-scrolls into view.
+- **Scroll-scrub the 3-way dasha-stagger timeline** → animates the three pivot dates with day-counts between each.
+
+## lessons
+
+*(No autoresearch passes yet. First Pass 6 entry will land here per autoresearch contract.)*


### PR DESCRIPTION
## Summary
Phase 1 of the reading-modes plan. Lands the unified runner `integratedreading-mode.ts` (single execution path for ALL reading modes) and ports the existing composite + triad runners into Markdown mode docs that get the multi-pass treatment solos already use.

The current composite/triad single-pass output (~4.5k words) becomes 4-pass (~12-15k words) without changing orchestrator code — only the mode docs.

## Closes
- Closes #38 — P1.1 unified orchestrator
- Closes #39 — P1.2 composite-dyad mode doc
- Closes #40 — P1.3 composite-triad mode doc
- Closes #41 — P1.4 legacy runners as thin shims

## What changed

**New**: `scripts/integratedreading-mode.ts` (~420 LOC)
- Unified runner for all reading modes
- CLI: `--mode --subjects-dir --output-dir [--use-cache] [--skip-solos] [--dry-run]`
- Loads mode doc → reads subjects → auto-chains missing solos in parallel → runs pass plan (linear or hierarchical) → assembles + renders SVG via topology dispatcher → emits metric report
- Per-pass cache (`pass_<id>.md`) so reruns are cheap
- All contract calls from `defaults.ts` (no re-declared constants)

**New**: `scripts/integratedreading/modes/composite-dyad.md` (~310 lines)
- 4-pass plan ported from `compositePrompt()` in system-prompts.ts:
  - Pass α (3,200w): Identity + Vedic
  - Pass β (3,600w): HD + Gene Keys + Mahadasha coherence event
  - Pass γ (3,400w): Marriage-already-already + Joint Career
  - Pass δ (3,000w): Health + Anti-Dependency + Final Synthesis
- Engine overlays per design § 3 (Vimshottari/HD/Gene Keys/Tarot foregrounded)
- Bridge mandate: 2+ chart layers per claim, phase-lock-as-geometry, per-Kosha anti-dependency

**New**: `scripts/integratedreading/modes/composite-triad.md` (~300 lines)
- 4-pass plan for 3-subject synastry, adapted for triangle geometry
- Bridge mandate: every claim names which PAIR carries it AND what the third subject provides

**Updated**: `scripts/integratedreading-composite.ts` and `-triad.ts` (~50 LOC each)
- Thin shims that materialize a temp subjects-directory + spawn the new orchestrator
- Preserve legacy CLI flags (`--subject-a/-b/-c --output-dir --use-cache`)
- Emit deprecation notice once per run

## Verification
- Both mode docs parse cleanly (4 passes each, all templates resolve)
- Dry-run on real fixtures: dyad (WA × Harshita) + triad (WA × Harshita × Mohan) — mode-doc + subject validation pass
- Legacy shim spawns the new orchestrator with correct flags
- All 21 P0 parser/dispatcher tests still pass

## Test plan
- [ ] Run \`npm test\` → 21/21 pass
- [ ] Dry-run orchestrator: \`integratedreading-mode.ts --mode composite-dyad --subjects-dir <dir> --output-dir <dir> --dry-run\`
- [ ] Optional full live run: same command without \`--dry-run\` — verify 4-pass output hits 12k+ words

## Out of scope
- Interactive HTML renderer (#42/#43/#44 — P2)
- Other modes (P3-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)