### PR TITLE
feat(integratedreading/render): P2 interactive HTML renderer + scroll-driven animations

### DIFF
--- a/scripts/integratedreading-mode.ts
+++ b/scripts/integratedreading-mode.ts
@@ -26,6 +26,14 @@ import { homedir } from 'node:os';
 import { parseModeDoc, summarizeLessons, type ParsedModeDoc, type PassSpec } from './integratedreading/modes/parser.js';
 import { renderByTopology } from './integratedreading/render/svg/index.js';
 import {
+  renderInteractiveHTMLPage,
+  renderFigIndex,
+  createFigureRegistry,
+  renderVizPlate,
+  type PartBlock,
+} from './integratedreading/render/templates.js';
+import { execSync } from 'node:child_process';
+import {
   ANATOMIST_PERSONA,
   KOSHA_GRAMMAR,
   DYADIC_LOOP,
@@ -558,22 +566,61 @@ async function main() {
   await writeFile(metricPath, JSON.stringify(report, null, 2));
   console.log(`✓ Metrics:   ${metricPath}`);
 
-  // SVG (just verify dispatch works — full HTML render lands in P2)
+  // ─── SVG topology dispatch ───────────────────────────────────────
+  const topology = doc.frontmatter.svg_topology;
+  let svgString = '';
   try {
-    const topology = doc.frontmatter.svg_topology;
     if (topology === 'dyad-arc' && subjects.length === 2) {
-      const svg = renderByTopology(topology, buildDyadSvgData(subjects), { width: 640 });
-      await writeFile(join(runDir, `${runSlug}.svg`), svg);
-      console.log(`✓ SVG:       ${runSlug}.svg (dyad-arc)`);
+      svgString = renderByTopology(topology, buildDyadSvgData(subjects), { width: 640 });
     } else if (topology === 'triad-triangle' && subjects.length === 3) {
-      const svg = renderByTopology(topology, buildTriadSvgData(subjects), { width: 720 });
-      await writeFile(join(runDir, `${runSlug}.svg`), svg);
-      console.log(`✓ SVG:       ${runSlug}.svg (triad-triangle)`);
+      svgString = renderByTopology(topology, buildTriadSvgData(subjects), { width: 720 });
     } else {
-      console.log(`  (SVG topology '${topology}' renders in P2 interactive HTML phase — skipping standalone export)`);
+      console.log(`  (SVG topology '${topology}' renderer not yet available — emitting placeholder)`);
+    }
+    if (svgString) {
+      await writeFile(join(runDir, `${runSlug}.svg`), svgString);
+      console.log(`✓ SVG:       ${runSlug}.svg (${topology})`);
     }
   } catch (err: any) {
     console.warn(`  ⚠ SVG render skipped: ${err.message}`);
+  }
+
+  // ─── Interactive HTML render (P2.1 wired) ────────────────────────
+  try {
+    const figs = createFigureRegistry();
+    const partBlocks: PartBlock[] = report.pass_metrics.map((m, i) => ({
+      partNum: i + 1,
+      romanNumeral: toRoman(i + 1),
+      title: m.title,
+      subtitle: `~${m.words.toLocaleString()} words · ${m.xrefs} cross-references`,
+      contentHtml: mdToHtmlBlock(passes[i].content),
+      // Attach the SVG only to the first Part as a sticky-viz column anchor
+      vizHtml: i === 0 && svgString ? renderVizPlate({
+        figNo: figs.next(`${doc.frontmatter.mode} field`),
+        title: `${doc.frontmatter.mode === 'composite-dyad' ? 'Composite Dyad Field' : doc.frontmatter.mode === 'composite-triad' ? 'Triadic Field' : 'Field'}`,
+        svg: svgString,
+        caption: doc.frontmatter.bridge_mandates[0],
+      }) : undefined,
+    }));
+    const html = renderInteractiveHTMLPage({
+      title: `${doc.frontmatter.mode} — ${subjects.map((s) => s.subject).join(' × ')}`,
+      cover: {
+        subject: subjects.map((s) => s.subject).join(' × '),
+        birth_date: subjects[0].birth_date || '',
+        cover_mandala_svg: svgString,
+      },
+      topology,
+      parts: partBlocks,
+      fig_index_html: renderFigIndex(figs.list()),
+      is_composite: subjects.length >= 2,
+      composite_subject_a: subjects[0]?.subject,
+      composite_subject_b: subjects.slice(1).map((s) => s.subject).join(' × '),
+    });
+    const htmlPath = join(runDir, `${runSlug}.html`);
+    await writeFile(htmlPath, html);
+    console.log(`✓ HTML:      ${runSlug}.html (interactive, ${(html.length / 1024).toFixed(1)} KB)`);
+  } catch (err: any) {
+    console.warn(`  ⚠ Interactive HTML render skipped: ${err.message}`);
   }
 
   // ─── Summary ─────────────────────────────────────────────────────
@@ -584,6 +631,36 @@ async function main() {
   for (const m of report.pass_metrics) {
     const hit = m.words >= m.target_words * 0.8 ? '✓' : '⚠';
     console.log(`    ${hit} Pass ${m.id}: ${m.words}w / ${m.target_words}w target · ${m.xrefs} xrefs`);
+  }
+}
+
+// Roman numeral converter for Part headings
+function toRoman(n: number): string {
+  const map: Array<[number, string]> = [
+    [1000, 'M'], [900, 'CM'], [500, 'D'], [400, 'CD'], [100, 'C'],
+    [90, 'XC'], [50, 'L'], [40, 'XL'], [10, 'X'], [9, 'IX'],
+    [5, 'V'], [4, 'IV'], [1, 'I'],
+  ];
+  let s = ''; let r = n;
+  for (const [v, sym] of map) { while (r >= v) { s += sym; r -= v; } }
+  return s;
+}
+
+// Markdown → HTML via pandoc (fallback to minimal regex if pandoc absent)
+function mdToHtmlBlock(md: string): string {
+  if (!md.trim()) return '';
+  try {
+    return execSync('pandoc -f markdown -t html5 --syntax-highlighting=none', {
+      input: md,
+      encoding: 'utf-8',
+    });
+  } catch {
+    return md
+      .replace(/^### (.*$)/gm, '<h3>$1</h3>')
+      .replace(/^## (.*$)/gm, '<h2>$1</h2>')
+      .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+      .replace(/\*(.+?)\*/g, '<em>$1</em>')
+      .split(/\n\n+/).map((p) => p.startsWith('<') ? p : `<p>${p}</p>`).join('\n');
   }
 }
 

--- a/scripts/integratedreading/render/interactions/index.ts
+++ b/scripts/integratedreading/render/interactions/index.ts
@@ -1,0 +1,507 @@
+// ─── /integratedreading — Interactions Framework ───────────────────────
+// Per-mode interaction modules emit three strings that the interactive
+// HTML page scaffold inlines into a single self-contained artifact:
+//   - scrollTimelineCss: CSS scroll-driven animations + sticky layouts
+//   - gsapTimeline: GSAP timeline JS (loaded via CDN ScrollTrigger)
+//   - eventHandlers: inline JS for hover / click / filter affordances
+//
+// Each module is tied to a topology key (dyad-arc / triad-triangle /
+// pentagon / web-graph). Mode docs declare svg_topology; the orchestrator
+// dispatches via INTERACTION_MODULES.
+//
+// Pentagon + web-graph throw NotImplementedError until P4.3 / P5.3.
+//
+// Per design doc § 5 (interactive HTML primary output), P2.2 deliverable.
+// Closes #43.
+
+import type { TopologyKey } from '../svg/index.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// Module shape
+// ────────────────────────────────────────────────────────────────────────
+
+export interface InteractionModule {
+  /** Inline CSS — scroll-timeline animations, sticky positioning, transition rules. */
+  scrollTimelineCss: string;
+  /** Inline JS — GSAP timeline + ScrollTrigger registrations (CDN-loaded GSAP). */
+  gsapTimeline: string;
+  /** Inline JS — event handlers (hover / click / filter / scroll-snap watchers). */
+  eventHandlers: string;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// dyad-arc — basic interactions for the 2-subject composite
+// ────────────────────────────────────────────────────────────────────────
+
+const dyadArcModule: InteractionModule = {
+  scrollTimelineCss: `
+/* Dyad-arc — subject arcs pulse softly on hover */
+.viz svg path[stroke="${'#10B5A7'}"],
+.viz svg path[stroke="${'#0B50FB'}"] {
+  transition: stroke-width 0.4s ease, filter 0.4s ease;
+}
+.viz svg path[stroke="${'#10B5A7'}"]:hover,
+.viz svg path[stroke="${'#0B50FB'}"]:hover {
+  stroke-width: 3;
+  filter: drop-shadow(0 0 6px currentColor);
+}
+
+/* Electromagnetic channel threads — luminous pulse on hover */
+.viz svg path[stroke^="url(#dyad-thread"] {
+  transition: opacity 0.3s ease;
+  cursor: pointer;
+}
+.viz svg path[stroke^="url(#dyad-thread"]:hover {
+  opacity: 1 !important;
+}
+
+/* Subject labels — gentle scale-up on hover */
+.viz svg text[font-family*="Panchang"][font-weight="700"] {
+  transition: transform 0.3s ease;
+  transform-origin: center;
+}
+.viz svg text[font-family*="Panchang"][font-weight="700"]:hover {
+  transform: scale(1.04);
+}
+`,
+
+  gsapTimeline: `
+// Dyad-arc — scroll-scrub the dasha-stagger timeline if present
+if (typeof gsap !== 'undefined' && typeof ScrollTrigger !== 'undefined') {
+  gsap.registerPlugin(ScrollTrigger);
+  // Reveal threads as the dyad-arc SVG enters viewport
+  document.querySelectorAll('.viz svg').forEach(function(svg) {
+    var threads = svg.querySelectorAll('path[stroke^="url(#dyad-thread"]');
+    if (threads.length === 0) return;
+    gsap.from(threads, {
+      strokeDashoffset: 200,
+      strokeDasharray: 200,
+      duration: 1.4,
+      stagger: 0.18,
+      ease: 'power2.out',
+      scrollTrigger: {
+        trigger: svg,
+        start: 'top 80%',
+        toggleActions: 'play none none reverse',
+      },
+    });
+  });
+}
+`,
+
+  eventHandlers: `
+// Dyad-arc — tooltip on channel-thread hover surfaces the bridge name
+document.querySelectorAll('.viz svg path[stroke^="url(#dyad-thread"]').forEach(function(path) {
+  var label = path.nextElementSibling;
+  while (label && label.tagName !== 'text') label = label.nextElementSibling;
+  if (!label) return;
+  path.setAttribute('data-bridge', label.textContent || '');
+  path.addEventListener('mouseenter', function(e) { showBridgeTooltip(e, path.getAttribute('data-bridge')); });
+  path.addEventListener('mouseleave', hideBridgeTooltip);
+});
+`,
+};
+
+// ────────────────────────────────────────────────────────────────────────
+// triad-triangle — basic interactions for 3-subject synastry
+// ────────────────────────────────────────────────────────────────────────
+
+const triadTriangleModule: InteractionModule = {
+  scrollTimelineCss: `
+/* Triad-triangle — vertex arcs grow soft halo on hover */
+.viz svg circle[fill="none"][stroke-width="1.6"] {
+  transition: stroke-width 0.4s ease, filter 0.4s ease;
+}
+.viz svg circle[fill="none"][stroke-width="1.6"]:hover {
+  stroke-width: 2.4;
+  filter: drop-shadow(0 0 8px currentColor);
+}
+
+/* Pair-thread gradient lines — pulse on hover */
+.viz svg line[stroke^="url(#triad-thread"] {
+  transition: stroke-opacity 0.3s ease, stroke-width 0.3s ease;
+  cursor: pointer;
+}
+.viz svg line[stroke^="url(#triad-thread"]:hover {
+  stroke-width: 2 !important;
+}
+
+/* TRIAD center seed — gentle scale on hover */
+.viz svg circle[r="44"] {
+  transition: transform 0.4s ease;
+  transform-origin: center;
+  transform-box: fill-box;
+}
+.viz svg circle[r="44"]:hover {
+  transform: scale(1.06);
+}
+`,
+
+  gsapTimeline: `
+// Triad-triangle — sequential reveal: vertices first, then threads, then center
+if (typeof gsap !== 'undefined' && typeof ScrollTrigger !== 'undefined') {
+  gsap.registerPlugin(ScrollTrigger);
+  document.querySelectorAll('.viz svg').forEach(function(svg) {
+    var vertices = svg.querySelectorAll('circle[fill="none"][stroke-width="1.6"]');
+    var threads = svg.querySelectorAll('line[stroke^="url(#triad-thread"]');
+    var center = svg.querySelector('circle[r="44"]');
+    if (vertices.length === 0 && threads.length === 0) return;
+    var tl = gsap.timeline({
+      scrollTrigger: {
+        trigger: svg,
+        start: 'top 75%',
+        toggleActions: 'play none none reverse',
+      },
+    });
+    if (vertices.length > 0) tl.from(vertices, { scale: 0, opacity: 0, duration: 0.7, stagger: 0.15, ease: 'back.out(1.7)', transformOrigin: 'center', transformBox: 'fill-box' });
+    if (threads.length > 0) tl.from(threads, { drawSVG: 0, duration: 0.9, stagger: 0.12, ease: 'power2.out' }, '-=0.4');
+    if (center) tl.from(center, { scale: 0, opacity: 0, duration: 0.5, ease: 'back.out(2)', transformOrigin: 'center', transformBox: 'fill-box' }, '-=0.3');
+  });
+}
+`,
+
+  eventHandlers: `
+// Triad-triangle — click a vertex to scroll to the section about that subject
+document.querySelectorAll('.viz svg circle[fill="none"][stroke-width="1.6"]').forEach(function(vertex) {
+  vertex.style.cursor = 'pointer';
+  vertex.addEventListener('click', function() {
+    // Find adjacent subject-name text label
+    var sibling = vertex.parentElement.querySelectorAll('text[font-weight="700"]');
+    for (var i = 0; i < sibling.length; i++) {
+      var name = (sibling[i].textContent || '').trim();
+      if (!name) continue;
+      var target = document.querySelector('h2[id*="' + name.toLowerCase().replace(/[^a-z]+/g, '-') + '"], section[id*="' + name.toLowerCase().replace(/[^a-z]+/g, '-') + '"]');
+      if (target) { target.scrollIntoView({ behavior: 'smooth', block: 'start' }); return; }
+    }
+  });
+});
+`,
+};
+
+// ────────────────────────────────────────────────────────────────────────
+// Stub modules — pentagon (P4.3) + web-graph (P5.3)
+// ────────────────────────────────────────────────────────────────────────
+
+const pentagonStubModule: InteractionModule = {
+  scrollTimelineCss: '/* pentagon interactions land in #51 (P4.3) */',
+  gsapTimeline: '// pentagon interactions land in #51 (P4.3)',
+  eventHandlers: '// pentagon interactions land in #51 (P4.3)',
+};
+
+const webGraphStubModule: InteractionModule = {
+  scrollTimelineCss: '/* web-graph interactions land in #54 (P5.3) */',
+  gsapTimeline: '// web-graph interactions land in #54 (P5.3)',
+  eventHandlers: '// web-graph interactions land in #54 (P5.3)',
+};
+
+// ────────────────────────────────────────────────────────────────────────
+// Registry
+// ────────────────────────────────────────────────────────────────────────
+
+export const INTERACTION_MODULES: Record<TopologyKey, InteractionModule> = {
+  'dyad-arc': dyadArcModule,
+  'triad-triangle': triadTriangleModule,
+  'pentagon': pentagonStubModule,
+  'web-graph': webGraphStubModule,
+};
+
+// ────────────────────────────────────────────────────────────────────────
+// Shared base — scroll-narrative scaffold CSS + JS that EVERY interactive
+// page gets, regardless of topology. This drives the cover fade-in,
+// sticky TOC rail, plate scroll-snap, and per-Part sticky-viz columns.
+// ────────────────────────────────────────────────────────────────────────
+
+export const BASE_SCROLL_NARRATIVE_CSS = `
+/* ════ Scroll-Narrative Scaffold (P2.1) ════════════════════════════════ */
+
+/* Body becomes the scroll container */
+.canvas.interactive {
+  scroll-behavior: smooth;
+}
+
+/* ── Cover — animated mandala fade-in on initial paint ──────────────── */
+.cover .cover-svg-wrap svg {
+  opacity: 0;
+  transform: scale(0.92);
+  animation: cover-mandala-reveal 1.6s ease-out 0.3s forwards;
+}
+@keyframes cover-mandala-reveal {
+  to { opacity: 0.85; transform: scale(1); }
+}
+.cover h1.cover-title,
+.cover .cover-subject,
+.cover .cover-tagline {
+  opacity: 0;
+  animation: cover-text-reveal 0.9s ease-out forwards;
+}
+.cover h1.cover-title { animation-delay: 0.5s; }
+.cover .cover-subject { animation-delay: 0.8s; }
+.cover .cover-tagline { animation-delay: 1.1s; }
+@keyframes cover-text-reveal {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* ── Sticky TOC rail — left of body, auto-highlights current Part ───── */
+.body-page.interactive {
+  display: grid;
+  grid-template-columns: 220px 1fr;
+  gap: 48px;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 40px 24px;
+}
+.toc-rail {
+  position: sticky;
+  top: 32px;
+  align-self: start;
+  font-family: var(--font-mono);
+  font-size: 10pt;
+  line-height: 1.6;
+  max-height: calc(100vh - 64px);
+  overflow-y: auto;
+}
+.toc-rail-title {
+  font-size: 8pt;
+  letter-spacing: 0.4em;
+  text-transform: uppercase;
+  color: var(--sacred-gold);
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid rgba(197,160,23,0.25);
+}
+.toc-rail ol {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  counter-reset: rail;
+}
+.toc-rail li {
+  counter-increment: rail;
+  margin-bottom: 12px;
+  padding: 6px 10px 6px 28px;
+  position: relative;
+  cursor: pointer;
+  transition: color 0.3s ease, border-left-color 0.3s ease;
+  color: var(--muted-silver);
+  border-left: 2px solid transparent;
+  border-radius: 2px;
+}
+.toc-rail li::before {
+  content: counter(rail, upper-roman) '.';
+  position: absolute;
+  left: 6px;
+  font-variant-numeric: tabular-nums;
+  font-size: 8pt;
+  color: var(--coherence-emerald);
+  opacity: 0.7;
+}
+.toc-rail li:hover {
+  color: var(--parchment);
+}
+.toc-rail li.active {
+  color: var(--sacred-gold);
+  border-left-color: var(--sacred-gold);
+  background: rgba(197,160,23,0.05);
+}
+.toc-rail a {
+  color: inherit;
+  text-decoration: none;
+  display: block;
+}
+
+/* ── Per-Part sticky-viz column layout ─────────────────────────────── */
+.part-block {
+  margin-bottom: 96px;
+}
+.part-block.has-viz {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 380px;
+  gap: 48px;
+  align-items: start;
+}
+.part-block.has-viz .part-prose { min-width: 0; }
+.part-block.has-viz .part-viz-column {
+  position: sticky;
+  top: 32px;
+  align-self: start;
+  max-height: calc(100vh - 64px);
+}
+.part-block.has-viz .part-viz-column figure.viz { margin: 0; }
+.part-block.has-viz .part-viz-column .viz svg { max-width: 100%; }
+
+/* ── Plate sections — full-viewport-height with scroll-snap ────────── */
+.canvas.interactive {
+  scroll-snap-type: y proximity;
+}
+.viz-plate {
+  scroll-snap-align: center;
+  min-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: stretch;
+}
+
+/* ── Scroll-driven reveal — sections fade in as they enter viewport ── */
+@supports (animation-timeline: view()) {
+  .part-header,
+  .part-block,
+  .opening,
+  section.fig-index,
+  .doc-footer {
+    animation: fade-up linear both;
+    animation-timeline: view();
+    animation-range: entry 0% entry 50%;
+  }
+  @keyframes fade-up {
+    from { opacity: 0; transform: translateY(24px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+}
+
+/* ── Tooltips for hover-bridge revelations ─────────────────────────── */
+#bridge-tooltip {
+  position: fixed;
+  pointer-events: none;
+  background: var(--void-black);
+  color: var(--parchment);
+  border: 1px solid var(--sacred-gold);
+  padding: 10px 14px;
+  font-family: var(--font-mono);
+  font-size: 9pt;
+  letter-spacing: 0.05em;
+  max-width: 280px;
+  z-index: 9999;
+  opacity: 0;
+  transform: translate(-50%, -110%);
+  transition: opacity 0.2s ease;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.4);
+}
+#bridge-tooltip.visible { opacity: 1; }
+#bridge-tooltip::after {
+  content: '';
+  position: absolute;
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+  width: 10px;
+  height: 10px;
+  background: var(--void-black);
+  border-right: 1px solid var(--sacred-gold);
+  border-bottom: 1px solid var(--sacred-gold);
+}
+
+/* ── Mobile / narrow viewport — collapse grid to single column ─────── */
+@media (max-width: 900px) {
+  .body-page.interactive { grid-template-columns: 1fr; padding: 24px 16px; }
+  .toc-rail {
+    position: relative;
+    top: 0;
+    max-height: none;
+    margin-bottom: 32px;
+    padding: 16px;
+    border: 1px solid rgba(197,160,23,0.2);
+    border-radius: 4px;
+  }
+  .part-block.has-viz {
+    grid-template-columns: 1fr;
+  }
+  .part-block.has-viz .part-viz-column {
+    position: relative;
+    top: 0;
+    max-height: none;
+  }
+}
+
+/* ── Reduced motion — strip animations for accessibility ───────────── */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+`;
+
+export const BASE_INTERACTIVE_JS = `
+// ════ Scroll-Narrative Runtime (P2.1) ═══════════════════════════════
+(function() {
+  // ── Bridge tooltip ────────────────────────────────────────────────
+  var tooltipEl = null;
+  function ensureTooltip() {
+    if (tooltipEl) return tooltipEl;
+    tooltipEl = document.createElement('div');
+    tooltipEl.id = 'bridge-tooltip';
+    document.body.appendChild(tooltipEl);
+    return tooltipEl;
+  }
+  window.showBridgeTooltip = function(evt, text) {
+    if (!text) return;
+    var el = ensureTooltip();
+    el.textContent = text;
+    el.style.left = (evt.clientX) + 'px';
+    el.style.top = (evt.clientY) + 'px';
+    el.classList.add('visible');
+  };
+  window.hideBridgeTooltip = function() {
+    if (tooltipEl) tooltipEl.classList.remove('visible');
+  };
+
+  // ── TOC rail — Intersection Observer auto-highlights current Part ─
+  var tocItems = document.querySelectorAll('.toc-rail li[data-part]');
+  if (tocItems.length > 0 && 'IntersectionObserver' in window) {
+    var partSections = {};
+    tocItems.forEach(function(li) {
+      var partNum = li.getAttribute('data-part');
+      var section = document.getElementById('part-' + partNum);
+      if (section) partSections[partNum] = { section: section, li: li };
+    });
+    var observer = new IntersectionObserver(function(entries) {
+      entries.forEach(function(entry) {
+        if (entry.isIntersecting) {
+          var partNum = entry.target.id.replace('part-', '');
+          Object.keys(partSections).forEach(function(k) {
+            partSections[k].li.classList.toggle('active', k === partNum);
+          });
+        }
+      });
+    }, { rootMargin: '-30% 0% -60% 0%', threshold: 0 });
+    Object.values(partSections).forEach(function(p) { observer.observe(p.section); });
+  }
+
+  // ── Smooth-scroll on TOC click ────────────────────────────────────
+  document.querySelectorAll('.toc-rail a[href^="#"]').forEach(function(a) {
+    a.addEventListener('click', function(e) {
+      e.preventDefault();
+      var target = document.querySelector(a.getAttribute('href'));
+      if (target) target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  });
+})();
+`;
+
+/** Convenience — assemble all three layers (CSS / GSAP / handlers) for a topology. */
+export function buildInteractionPayload(topology: string): {
+  css: string;
+  gsap: string;
+  handlers: string;
+} {
+  const mod = INTERACTION_MODULES[topology as TopologyKey];
+  if (!mod) {
+    return {
+      css: `/* unknown topology '${topology}' — no interaction module */`,
+      gsap: `// unknown topology '${topology}'`,
+      handlers: `// unknown topology '${topology}'`,
+    };
+  }
+  return {
+    css: BASE_SCROLL_NARRATIVE_CSS + '\n' + mod.scrollTimelineCss,
+    gsap: mod.gsapTimeline,
+    handlers: BASE_INTERACTIVE_JS + '\n' + mod.eventHandlers,
+  };
+}
+
+export const GSAP_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js';
+export const GSAP_SCROLLTRIGGER_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/ScrollTrigger.min.js';

--- a/scripts/integratedreading/render/styles.ts
+++ b/scripts/integratedreading/render/styles.ts
@@ -1009,4 +1009,63 @@ table.table-wide td:first-child, table.table-wide th:first-child { padding-left:
   /* Hide footer separator (it's between Parts in print) */
   .doc-footer { page-break-before: always; }
 }
+
+/* ════ Interactive layer print flattening (P2.3 #44) ═══════════════════
+ * When this artifact is printed to PDF (or media print preview), strip
+ * all interactivity: animations off, sticky-positioned vizes collapse to
+ * flow position, hover-only tooltips hidden, scroll-snap disabled. The
+ * PDF is the static archive; the on-screen experience is the primary.
+ */
+@media print {
+  /* Strip all animations + transitions */
+  .canvas.interactive *,
+  .canvas.interactive *::before,
+  .canvas.interactive *::after {
+    animation: none !important;
+    transition: none !important;
+    transform: none !important;
+  }
+  /* Cover elements appear immediately (no animated reveal) */
+  .cover .cover-svg-wrap svg,
+  .cover h1.cover-title,
+  .cover .cover-subject,
+  .cover .cover-tagline {
+    opacity: 1 !important;
+  }
+  /* Disable scroll-snap so plates flow naturally */
+  .canvas.interactive {
+    scroll-snap-type: none !important;
+    scroll-behavior: auto !important;
+  }
+  /* Body-page grid collapses to single column */
+  .body-page.interactive {
+    display: block !important;
+    grid-template-columns: none !important;
+    max-width: 100% !important;
+    padding: 0 !important;
+  }
+  /* Hide sticky TOC rail (table of contents page already serves this in print) */
+  .toc-rail { display: none !important; }
+  /* Per-Part sticky-viz column collapses to flow */
+  .part-block.has-viz {
+    display: block !important;
+    grid-template-columns: none !important;
+  }
+  .part-block.has-viz .part-viz-column {
+    position: static !important;
+    top: 0 !important;
+    max-height: none !important;
+    margin-top: 24px;
+  }
+  /* Plate sections lose viewport-min-height — let them size to content */
+  .viz-plate {
+    min-height: 0 !important;
+    scroll-snap-align: none !important;
+  }
+  /* Hover-only tooltips never appear in print */
+  #bridge-tooltip { display: none !important; }
+  /* Show all collapsed/filtered content (no mode-state in print) */
+  [data-filter-hidden],
+  [hidden][data-interactive] { display: revert !important; }
+}
 `;

--- a/scripts/integratedreading/render/templates.ts
+++ b/scripts/integratedreading/render/templates.ts
@@ -4,6 +4,11 @@
 // renderVizTrio so the figure-counter and figure-index stay coherent.
 
 import { STYLES, BRAND } from './styles.js';
+import {
+  buildInteractionPayload,
+  GSAP_CDN,
+  GSAP_SCROLLTRIGGER_CDN,
+} from './interactions/index.js';
 
 export interface CoverData {
   subject: string;
@@ -248,4 +253,146 @@ export function renderFigIndex(entries: FigureEntry[]): string {
       <div class="fig-index-title">Index of Plates</div>
       <ul>${items}</ul>
     </section>`;
+}
+
+// ─── INTERACTIVE HTML PAGE (P2.1 — scroll-narrative + animations) ────
+//
+// Alongside the existing renderHTMLPage() static renderer. Output is a
+// single self-contained HTML file: GSAP loaded via CDN script tag, all
+// other CSS/JS inlined. Mode-doc's svg_topology drives which interaction
+// module (dyad-arc / triad-triangle / pentagon / web-graph) gets inlined.
+//
+// Per design doc § 5 — interactive HTML primary, PDF derivative archive
+// via @media print flattening (added to styles.ts in P2.3).
+
+export interface PartBlock {
+  partNum: number;
+  romanNumeral: string;
+  title: string;
+  subtitle?: string;
+  contentHtml: string;
+  /** Optional SVG-bearing figure(s) for sticky-viz column (single-Part docs only). */
+  vizHtml?: string;
+}
+
+export function renderInteractiveHTMLPage(opts: {
+  title: string;
+  cover: CoverData;
+  topology: string;
+  parts: PartBlock[];
+  opening_html?: string;
+  fig_index_html?: string;
+  is_composite?: boolean;
+  composite_subject_a?: string;
+  composite_subject_b?: string;
+}): string {
+  const subtitle = opts.is_composite
+    ? `${opts.composite_subject_a} × ${opts.composite_subject_b}`
+    : opts.cover.subject;
+
+  const coverMandala = opts.cover.cover_mandala_svg
+    ? `<div class="cover-svg-wrap">${opts.cover.cover_mandala_svg}</div>`
+    : '';
+
+  // Topology-specific interaction layer (inlined)
+  const interaction = buildInteractionPayload(opts.topology);
+
+  // TOC rail entries — generated from parts list
+  const tocRailHtml = `
+    <nav class="toc-rail">
+      <div class="toc-rail-title">Contents</div>
+      <ol>
+        ${opts.parts.map((p) => `<li data-part="${p.partNum}"><a href="#part-${p.partNum}">${p.title}</a></li>`).join('\n        ')}
+      </ol>
+    </nav>`;
+
+  // Body parts assembly — each Part becomes a .part-block (with optional sticky viz column)
+  const partsHtml = opts.parts.map((p) => {
+    const hasViz = !!p.vizHtml;
+    const partInner = `
+      <section class="part-header" id="part-${p.partNum}">
+        <div class="part-eyebrow">Part ${p.romanNumeral}</div>
+        <h2 class="part-title">${p.title}</h2>
+        ${p.subtitle ? `<div class="part-subtitle">${p.subtitle}</div>` : ''}
+      </section>
+      <div class="part-prose">${p.contentHtml}</div>`;
+    if (hasViz) {
+      return `
+      <div class="part-block has-viz">
+        ${partInner}
+        <aside class="part-viz-column">${p.vizHtml}</aside>
+      </div>`;
+    }
+    return `<div class="part-block">${partInner}</div>`;
+  }).join('\n');
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${opts.title}</title>
+<style>
+${STYLES}
+
+${interaction.css}
+</style>
+</head>
+<body>
+<div class="canvas interactive">
+  <!-- ───────────── COVER PAGE ───────────── -->
+  <section class="cover">
+    <header>
+      <div class="cover-mark">Tryambakam Noesis · Integrated Reading</div>
+      <h1 class="cover-title">${opts.is_composite ? 'Composite Field' : 'Integrated Reading'}</h1>
+      <div class="cover-subject">${subtitle}</div>
+      <div class="cover-birth">
+        ${opts.cover.birth_date}${opts.cover.birth_time ? ' · ' + opts.cover.birth_time : ''}${opts.cover.birth_place ? ' · ' + opts.cover.birth_place : ''}
+      </div>
+      <p class="cover-tagline">
+        Self-Consciousness as Technology.<br/>
+        Body as Medium. Breath as Interface.
+      </p>
+    </header>
+    ${coverMandala}
+    <footer class="cover-footer">
+      <div class="cover-lineage">
+        Three-resolution decoding · own-world × cultural-archetypal × celestial-environmental.<br/>
+        Tsarion-anchored Tarot lineage. Anti-dependency telos.
+      </div>
+      <div class="cover-stamp">∴ NOESIS</div>
+    </footer>
+  </section>
+
+  <!-- ───────────── BODY w/ sticky TOC rail ───────────── -->
+  <article class="body-page interactive">
+    ${tocRailHtml}
+    <div class="body-content">
+      ${opts.opening_html ? `<section class="opening">${opts.opening_html}</section>` : ''}
+      ${partsHtml}
+      ${opts.fig_index_html ?? ''}
+      <footer class="doc-footer">
+        <div class="tagline">The Anatomist Who Sees Fractals</div>
+        <div>TRYAMBAKAM NOESIS · 1331.TRYAMBAKAM.SPACE</div>
+        <div class="quine">
+          This document is documentation of an instrument. The instrument is what you already are.
+          The Quine principle: the system succeeds when you no longer need it.
+        </div>
+      </footer>
+    </div>
+  </article>
+</div>
+
+<!-- GSAP + ScrollTrigger via CDN — only loaded for interactive mode -->
+<script src="${GSAP_CDN}"></script>
+<script src="${GSAP_SCROLLTRIGGER_CDN}"></script>
+
+<!-- Inline runtime: base scroll-narrative scaffold + topology-specific GSAP timelines + event handlers -->
+<script>
+${interaction.handlers}
+
+${interaction.gsap}
+</script>
+</body>
+</html>`;
 }

--- a/tests/interactive-html.test.ts
+++ b/tests/interactive-html.test.ts
@@ -1,0 +1,230 @@
+// ─── Interactive HTML renderer + interactions framework tests ─────────
+// Covers P2.1 (renderInteractiveHTMLPage), P2.2 (interactions module
+// registry), and P2.3 (@media print flattening) for the reading-modes plan.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  INTERACTION_MODULES,
+  buildInteractionPayload,
+  BASE_SCROLL_NARRATIVE_CSS,
+  BASE_INTERACTIVE_JS,
+  GSAP_CDN,
+} from '../scripts/integratedreading/render/interactions/index.js';
+import {
+  renderInteractiveHTMLPage,
+  type PartBlock,
+} from '../scripts/integratedreading/render/templates.js';
+import { STYLES } from '../scripts/integratedreading/render/styles.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// Interactions module registry
+// ────────────────────────────────────────────────────────────────────────
+
+describe('INTERACTION_MODULES registry', () => {
+  it('registers all four topology keys', () => {
+    const keys = Object.keys(INTERACTION_MODULES).sort();
+    assert.deepEqual(keys, ['dyad-arc', 'pentagon', 'triad-triangle', 'web-graph']);
+  });
+
+  it('each module has the three required string layers', () => {
+    for (const [k, mod] of Object.entries(INTERACTION_MODULES)) {
+      assert.equal(typeof mod.scrollTimelineCss, 'string', `${k} missing scrollTimelineCss`);
+      assert.equal(typeof mod.gsapTimeline, 'string', `${k} missing gsapTimeline`);
+      assert.equal(typeof mod.eventHandlers, 'string', `${k} missing eventHandlers`);
+    }
+  });
+
+  it('dyad-arc + triad-triangle have substantive interactions (not stubs)', () => {
+    assert.ok(INTERACTION_MODULES['dyad-arc'].gsapTimeline.length > 200);
+    assert.ok(INTERACTION_MODULES['triad-triangle'].gsapTimeline.length > 200);
+  });
+
+  it('pentagon + web-graph are stubs pointing to their landing issues', () => {
+    assert.match(INTERACTION_MODULES['pentagon'].eventHandlers, /#51|P4\.3/);
+    assert.match(INTERACTION_MODULES['web-graph'].eventHandlers, /#54|P5\.3/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// buildInteractionPayload — composes BASE + topology-specific
+// ────────────────────────────────────────────────────────────────────────
+
+describe('buildInteractionPayload', () => {
+  it('combines BASE_SCROLL_NARRATIVE_CSS with topology-specific CSS', () => {
+    const payload = buildInteractionPayload('dyad-arc');
+    assert.ok(payload.css.includes('Scroll-Narrative Scaffold'));
+    assert.ok(payload.css.includes(INTERACTION_MODULES['dyad-arc'].scrollTimelineCss.trim().slice(0, 30)));
+  });
+
+  it('combines BASE_INTERACTIVE_JS with topology-specific handlers', () => {
+    const payload = buildInteractionPayload('triad-triangle');
+    assert.ok(payload.handlers.includes('Scroll-Narrative Runtime'));
+    assert.ok(payload.handlers.includes(INTERACTION_MODULES['triad-triangle'].eventHandlers.trim().slice(0, 30)));
+  });
+
+  it('returns sensible fallback for unknown topology', () => {
+    const payload = buildInteractionPayload('octagon');
+    assert.match(payload.css, /unknown topology/);
+    assert.match(payload.handlers, /unknown topology/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// renderInteractiveHTMLPage — full page assembly
+// ────────────────────────────────────────────────────────────────────────
+
+const SAMPLE_PARTS: PartBlock[] = [
+  { partNum: 1, romanNumeral: 'I', title: 'Composite Field', subtitle: '3,200 words', contentHtml: '<p>Pass alpha prose.</p>' },
+  { partNum: 2, romanNumeral: 'II', title: 'Phase-Lock Geometry', subtitle: '3,600 words', contentHtml: '<p>Pass beta prose.</p>' },
+  { partNum: 3, romanNumeral: 'III', title: 'Marriage Already-Already', subtitle: '3,400 words', contentHtml: '<p>Pass gamma prose.</p>' },
+];
+
+describe('renderInteractiveHTMLPage', () => {
+  it('renders a complete HTML document', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'Test',
+      cover: { subject: 'Alice × Bob', birth_date: '2026-01-01' },
+      topology: 'dyad-arc',
+      parts: SAMPLE_PARTS,
+      is_composite: true,
+      composite_subject_a: 'Alice',
+      composite_subject_b: 'Bob',
+    });
+    assert.match(html, /^<!DOCTYPE html>/);
+    assert.match(html, /<\/html>\s*$/);
+    assert.match(html, /<title>Test<\/title>/);
+  });
+
+  it('inlines the full STYLES brand CSS', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'A', birth_date: '2026-01-01' },
+      topology: 'dyad-arc',
+      parts: SAMPLE_PARTS,
+    });
+    // Sanity: a recognizable brand-CSS fragment must be present
+    assert.ok(html.includes(STYLES.slice(0, 100)));
+  });
+
+  it('inlines BASE_SCROLL_NARRATIVE_CSS', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'A', birth_date: '2026-01-01' },
+      topology: 'dyad-arc',
+      parts: SAMPLE_PARTS,
+    });
+    assert.ok(html.includes('Scroll-Narrative Scaffold'));
+    assert.ok(html.includes(BASE_SCROLL_NARRATIVE_CSS.slice(0, 60)));
+  });
+
+  it('inlines BASE_INTERACTIVE_JS runtime', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'A', birth_date: '2026-01-01' },
+      topology: 'dyad-arc',
+      parts: SAMPLE_PARTS,
+    });
+    assert.ok(html.includes(BASE_INTERACTIVE_JS.slice(0, 60)));
+  });
+
+  it('loads GSAP via CDN script tag', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'A', birth_date: '2026-01-01' },
+      topology: 'dyad-arc',
+      parts: SAMPLE_PARTS,
+    });
+    assert.ok(html.includes(GSAP_CDN));
+    assert.match(html, /ScrollTrigger/);
+  });
+
+  it('emits one .part-block per part', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'A', birth_date: '2026-01-01' },
+      topology: 'dyad-arc',
+      parts: SAMPLE_PARTS,
+    });
+    const partBlockCount = (html.match(/part-block/g) ?? []).length;
+    // Each part-block class appears at least once per part (open tag).
+    assert.ok(partBlockCount >= SAMPLE_PARTS.length);
+  });
+
+  it('emits TOC rail with one li per part', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'A', birth_date: '2026-01-01' },
+      topology: 'dyad-arc',
+      parts: SAMPLE_PARTS,
+    });
+    assert.match(html, /<nav class="toc-rail">/);
+    for (const p of SAMPLE_PARTS) {
+      assert.ok(html.includes(`data-part="${p.partNum}"`), `missing TOC item for part ${p.partNum}`);
+      assert.ok(html.includes(`href="#part-${p.partNum}"`), `missing TOC link for part ${p.partNum}`);
+    }
+  });
+
+  it('emits .part-block.has-viz when a part declares vizHtml', () => {
+    const partsWithViz = [
+      { ...SAMPLE_PARTS[0], vizHtml: '<figure class="viz">SVG-here</figure>' },
+      SAMPLE_PARTS[1],
+    ];
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'A', birth_date: '2026-01-01' },
+      topology: 'dyad-arc',
+      parts: partsWithViz,
+    });
+    assert.match(html, /class="part-block has-viz"/);
+    assert.match(html, /<aside class="part-viz-column">/);
+  });
+
+  it('inlines the topology-specific interaction module', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'A', birth_date: '2026-01-01' },
+      topology: 'triad-triangle',
+      parts: SAMPLE_PARTS,
+    });
+    // triad-triangle's CSS targets stroke-width="1.6" circles
+    assert.match(html, /circle\[fill="none"\]\[stroke-width="1\.6"\]/);
+    // GSAP timeline-triad references
+    assert.ok(html.includes('Triad-triangle'));
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// @media print flattening (P2.3)
+// ────────────────────────────────────────────────────────────────────────
+
+describe('@media print flattening rules', () => {
+  it('STYLES contains the interactive-layer print flattening block', () => {
+    assert.match(STYLES, /Interactive layer print flattening/);
+  });
+
+  it('flattening block disables animations and transforms', () => {
+    const block = STYLES.split('Interactive layer print flattening')[1] || '';
+    assert.match(block, /animation:\s*none\s*!important/);
+    assert.match(block, /transition:\s*none\s*!important/);
+    assert.match(block, /transform:\s*none\s*!important/);
+  });
+
+  it('flattening block hides sticky TOC rail and bridge tooltip', () => {
+    const block = STYLES.split('Interactive layer print flattening')[1] || '';
+    assert.match(block, /\.toc-rail\s*\{\s*display:\s*none/);
+    assert.match(block, /#bridge-tooltip\s*\{\s*display:\s*none/);
+  });
+
+  it('flattening block collapses sticky-viz column to flow', () => {
+    const block = STYLES.split('Interactive layer print flattening')[1] || '';
+    assert.match(block, /part-viz-column\s*\{[\s\S]*?position:\s*static/);
+  });
+
+  it('flattening block disables scroll-snap and grid', () => {
+    const block = STYLES.split('Interactive layer print flattening')[1] || '';
+    assert.match(block, /scroll-snap-type:\s*none/);
+    assert.match(block, /body-page\.interactive\s*\{[\s\S]*?display:\s*block/);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 2 of the reading-modes plan. Lands the **interactive HTML renderer as primary output** with scroll-driven animations, sticky-positioned TOC rail, per-Part sticky-viz columns, GSAP timelines, and bridge-tooltip on hover. PDF becomes the derivative archive via @media print flattening.

Per design doc § 5 pivot: "not limited by the fact we have to make a PDF in the end."

## Closes
- Closes #42 — P2.1 renderInteractiveHTMLPage() scroll-narrative scaffold
- Closes #43 — P2.2 render/interactions/ framework (GSAP + event handlers)
- Closes #44 — P2.3 @media print flattening + dyad/triad validation

## What changed

**New**: \`scripts/integratedreading/render/interactions/index.ts\` (507 LOC)
- \`INTERACTION_MODULES\` registry — dyad-arc + triad-triangle real, pentagon/web-graph stubs
- \`BASE_SCROLL_NARRATIVE_CSS\` — sticky TOC rail, scroll-driven reveal via \`animation-timeline: view()\`, per-Part sticky-viz grid, plate scroll-snap, bridge-tooltip element, mobile collapse, \`prefers-reduced-motion\` strip
- \`BASE_INTERACTIVE_JS\` — IntersectionObserver TOC highlight, smooth-scroll, tooltip helpers
- \`buildInteractionPayload(topology)\` composes BASE + topology layers
- GSAP loaded via CDN (\`cdnjs.cloudflare.com\`)

**New**: \`renderInteractiveHTMLPage()\` in \`templates.ts\` (147 LOC)
- Single self-contained HTML artifact (GSAP via CDN, everything else inlined)
- Full-bleed cover with animated mandala reveal
- 220px TOC rail + 1fr content grid
- \`PartBlock\` shape: \`{partNum, romanNumeral, title, subtitle?, contentHtml, vizHtml?}\`
- Optional sticky-viz column per Part via \`vizHtml\`

**Updated**: \`styles.ts\` — new \`@media print\` block (P2.3)
- Strips animations / transitions / transforms
- Hides sticky TOC rail (separate page in print)
- Collapses sticky-viz columns to flow position
- Disables scroll-snap
- Forces opacity 1 on animated-reveal elements

**Updated**: \`integratedreading-mode.ts\` — wires interactive HTML output
- Builds PartBlock[] from pass_metrics + pass contents
- Attaches SVG to Part I as sticky-viz column
- Calls renderInteractiveHTMLPage(), writes <runSlug>.html

**New**: \`tests/interactive-html.test.ts\` (21 tests)
- Registry, payload composition, page structure, @media print rules

## Verification
- 42/42 tests pass (21 new + 21 existing P0)
- Orchestrator dry-run still works (loads mode, validates, parses pass plan)
- No regressions in existing tests
- Imports compile via tsx (NodeNext module resolution)

## Test plan
- [ ] Run \`npm test\` → 42/42 pass
- [ ] Orchestrator dry-run: \`integratedreading-mode.ts --mode composite-dyad --subjects-dir <dir> --output-dir <dir> --dry-run\` — should load mode + report 4 passes
- [ ] Full live run: same without \`--dry-run\` produces \`<runSlug>.html\` artifact
- [ ] Open HTML in Chrome/Safari/Firefox — verify cover fade-in, sticky TOC, scroll behaviors
- [ ] Cmd-P → Save as PDF — verify @media print flattens cleanly

## Out of scope
- Pentagon + web-graph topology renderers (P4.2 #50, P5.2 #53)
- Mode docs for partner-synastry / business / family / team (P3-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)