### PR TITLE
feat(integratedreading): P3 Partner-Synastry + Business-Partners modes

### DIFF
--- a/scripts/integratedreading-mode.ts
+++ b/scripts/integratedreading-mode.ts
@@ -610,6 +610,8 @@ async function main() {
         cover_mandala_svg: svgString,
       },
       topology,
+      mode: doc.frontmatter.mode,
+      bridge_mandate: doc.frontmatter.bridge_mandates[0],
       parts: partBlocks,
       fig_index_html: renderFigIndex(figs.list()),
       is_composite: subjects.length >= 2,

--- a/scripts/integratedreading/modes/business-partners.md
+++ b/scripts/integratedreading/modes/business-partners.md
@@ -1,0 +1,313 @@
+---
+mode: business-partners
+subject_count:
+  min: 2
+  max: 2
+roles:
+  - founder
+  - co-founder
+target_words:
+  min: 12000
+  max: 15000
+architecture: linear
+pass_plan:
+  - id: alpha
+    title: "Dharma-Signature Alignment"
+    target_words: 3500
+    template: pass-alpha-template
+  - id: beta
+    title: "Joint-Operative Field"
+    target_words: 3500
+    template: pass-beta-template
+  - id: gamma
+    title: "Friction & Failure-Mode Mapping"
+    target_words: 3500
+    template: pass-gamma-template
+  - id: delta
+    title: "Build-Sequence Milestones"
+    target_words: 3000
+    template: pass-delta-template
+engine_overlay_weights:
+  atmakaraka: 2.0
+  vimshottari: 2.0
+  human-design: 1.5
+  gene-keys: 1.5
+  i-ching: 1.5
+  tarot: 1.0
+  panchanga: 1.0
+  transits: 1.0
+  biorhythm: 0.5
+  nadabrahman: 0.5
+  face-reading: 0.3
+  sigil-forge: 0.3
+house_overlay: [10, 11, 2, 6, 9]
+bridge_mandates:
+  - "Every major claim must braid: Atmakaraka-role-signature × Vimshottari-overlap-state × HD-authority-match × Gene-Key-gift-vector. Operational-specificity beats archetypal-poetry in this mode."
+  - "Friction in Pass γ must surface SPECIFIC operational vulnerabilities tied to chart-architectural gaps, NOT abstract personality differences."
+  - "Build-Sequence Milestones in Pass δ name WHAT the partnership SHIPS WHEN, anchored in the dasha overlap matrix — not generic strategic advice."
+svg_topology: dyad-arc
+---
+
+> **NOTE on subject count:** v1 ships as a 2-subject dyad. A 3-partner variant
+> (founder + co-founder + operating-partner) is tracked in the design doc as
+> a future enhancement — the triad-triangle SVG already exists, but the
+> 3-partner role-stack-overlay logic needs its own mode doc once the
+> first 2-partner runs validate the bridge-mandate quality.
+
+## pass-alpha-template
+
+You are running Pass α of the 4-pass **business-partners** synthesis for {{subject_names}}. This is an operational reading — two charts as one joint-operative instrument.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+Business-partners is DIFFERENT from romantic synastry in one structural respect: the 10th house (career / dharma signature) is the primary architectural anchor, not the 7th. The pair is operative as one field IN THE OPERATIONAL DOMAIN — what they build, how they build it, when they build it. Hold that throughout.
+
+Operational specificity beats archetypal poetry in this mode. Don't dilute into general spiritual language — the partners need to know whose Atmakaraka carries which role, whose dasha overlap window opens what build-sequence.
+
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES FOR THIS PASS
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+# Business-Partners Reading — {{subject_names}}
+
+## Opening — The Pair as One Joint Operative
+
+*(2-3 paragraphs. Frame the partnership as an OPERATIONAL INSTRUMENT, not a relational one. The 10th-house axis (career / dharma) is the literal architectural anchor of this reading; the 7th house is secondary here. State whether the chart-evidence supports the framing that the pair is structurally CONFIGURED to build something together — and if so, what KIND of build the chart prescribes.)*
+
+## Part I — Dharma-Signature Alignment
+
+### 1.1 Atmakaraka Comparison
+*(For each subject, name their Atmakaraka (highest-degree graha) and what it signifies for their soul-purpose. Then the comparative analysis: are the two Atmakarakas COMPLEMENTARY (e.g., Jupiter + Mercury — vision + execution), AT TENSION (e.g., Sun + Saturn — sovereignty vs structure), or REINFORCING (same Atmakaraka — shared soul-purpose, but watch for redundancy)?)*
+
+### 1.2 The 10th-House Cross-Overlay
+*(Each subject's 10th house — sign, lord, occupants. Then the cross-overlay: what graha from subject A's chart sits in subject B's 10th house position (and vice versa)? This is where one partner LITERALLY OCCUPIES the other's dharma-signature space.)*
+
+### 1.3 Role-Stack: Vision (Jupiter) × Operations (Saturn) × Execution (Mars)
+*(In any joint operative, three structural roles emerge: VISION (held by Jupiter signal), OPERATIONS (held by Saturn signal), EXECUTION (held by Mars signal). For this pair:*
+*— Which subject's Jupiter is the stronger / better-placed? They carry vision.*
+*— Which subject's Saturn is the stronger / better-placed? They carry operations.*
+*— Which subject's Mars is the stronger / better-placed? They carry execution.*
+
+*Be specific — point to actual placements. If a role is split (each carries half a signal), name that as a STRUCTURAL FRICTION POINT that needs explicit role-clarification before the build can scale. Tag elements with `data-role` attributes for the interactive role-filter.)*
+
+### 1.4 Sun-Mercury Operating-Day Signal
+*(Each subject's Sun + Mercury condition. Sun = the operational center / executive function. Mercury = communication / contract-handling / day-to-day decision-velocity. When the pair operates as one, who holds each of these? If both subjects have strong Mercury but weak Sun, the partnership will OVER-DELIBERATE; if both have strong Sun but weak Mercury, it will OVER-EXECUTE without communicating. Name the actual pattern.)*
+
+End Pass α. Pass β will move into the joint-operative field (Vimshottari overlap, HD authority match, Gene Key gifts, I-Ching state).
+
+## pass-beta-template
+
+You are running Pass β of the business-partners synthesis for {{subject_names}}. Pass α has established the dharma-signature alignment.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part II — Joint-Operative Field
+
+### 2.1 The Vimshottari Overlap Matrix
+*(THE keystone subsection of this Pass. Plot both subjects' Mahadasha-Antardasha overlap matrix for the next 8-12 years:*
+
+*For each year, for each Antardasha period, what is each subject in?*
+
+*Example row: "2026 Sep – 2027 May: Subject A in [Jupiter MD / Ketu AD], Subject B in [Venus MD / Saturn AD]. Joint signal: dharmic-grace × relational-resource-discipline. Operationally: this is a build-and-formalize window — A holds vision, B holds the legal/structural formalization."*
+
+*Mark each overlap cell with a `<span class="vimshottari-cell">` so the interactive layer can attach click-to-expand. Add a `<div class="vimshottari-expansion">` after each with the year-by-year operational reading.*
+
+*Identify the SPECIFIC overlap windows that are structurally generative vs the ones that are friction-bearing. The pair should know which 6-month windows to scale on and which to consolidate in.)*
+
+### 2.2 HD Authority + Strategy Compatibility
+*(Each subject's HD Type + Authority + Strategy. Then the operational compatibility:*
+
+*— Generator + Generator: response-based co-decision; both need to feel-into.*
+*— Projector + Generator: invitation-asks-response; the Projector waits for the Generator's invitation but recognizes opportunities the Generator can't see.*
+*— Manifestor + Generator: inform-then-respond; the Manifestor initiates, the Generator responds; if the Manifestor doesn't inform, the Generator goes silent.*
+*— Etc.*
+
+*Name THE ACTUAL CONFIGURATION. State the operational protocol — how decisions should flow between the two for the field to remain coherent.)*
+
+### 2.3 Gene Key Gifts Overlay — What Each Brings to the Joint Operative
+*(For each subject, name their:*
+*— Activation sphere (the chart's evolutionary work)*
+*— Evolution sphere (the chart's growth challenge)*
+*— Radiance sphere (the chart's body-current / health-current)*
+*— Purpose sphere (the chart's deepest contribution)*
+*— Pearl (the prosperity codon — what they materially generate)*
+
+*Then the joint analysis: what gift does each partner BRING to the build that the other doesn't have alone? Where do Pearls couple to make the pair's prosperity-current?)*
+
+### 2.4 I-Ching State of the Partnership
+*(Compute the I-Ching hexagram for the partnership — using either both subjects' Sun-line Gene Keys composed, or the day of the partnership's formal founding. Name the hexagram + its changing lines. Decode what the hexagram says about the partnership's current operational moment and where it's tending.)*
+
+End Pass β. Pass γ moves to friction + failure-mode mapping.
+
+## pass-gamma-template
+
+You are running Pass γ — the **friction & failure-mode mapping** pass — of the business-partners synthesis for {{subject_names}}. This is the pass where operational specificity matters most.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+This is NOT abstract personality-difference analysis. Name SPECIFIC, OPERATIONALLY-CONSEQUENTIAL vulnerabilities tied to chart-architectural gaps. If the chart says "Subject A has Mars debilitated in 6th — they will under-confront adversaries", say exactly that. The partners must walk away knowing WHICH operational decisions they are structurally configured to GET WRONG.
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part III — Friction & Failure-Mode Mapping
+
+### 3.1 6th-House Adversities Cross-Mapped
+*(The 6th house carries adversity, competition, debt, daily-grind, and operational obstacles. Map each subject's 6th-house signature. Then the cross-map: when a planet in A's chart sits in B's 6th-house position, that planet's archetypal current shows up AS adversary in B's life. Name each cross-mapping. These are the partnership's BUILT-IN external-vulnerability vectors — where the field is structurally exposed to specific kinds of friction.)*
+
+### 3.2 Debility / Combustion Compensations
+*(Where each subject has a debilitated or combust planet, the other partner often (not always) carries the compensation. Name each one: "Subject A has Mars combust by Sun (Mars within 17° of Sun) — they will OVERRIDE their own execution-impulse with self-narration about it. Subject B's Mars is well-placed in own sign — they carry the actual execution-current for the pair." Be that specific.)*
+
+### 3.3 Where the Joint Operative is Structurally Vulnerable
+*(Synthesize 3.1 + 3.2 into a vulnerability table: 3-5 specific failure modes the partnership is structurally configured to walk into. For each, name:*
+*— The chart-architectural source (which placements)*
+*— The operational manifestation (what it looks like in actual work)*
+*— The early-warning signal (what to notice)*
+*— The remediation lever (NOT generic — tied to chart-architecture: e.g., "in subject A's Saturn-MD windows, A's structural-discipline is online — those are the windows to ratify legal/operational structures, not earlier")*
+
+### 3.4 The Communication Failure Mode
+*(Specifically: where Mercury, Vedic + HD throat-center + tarot Magician current, is structurally weak in the pair. What kinds of communication WILL break down — and what specific protocol catches it.)*
+
+End Pass γ. Pass δ closes with build-sequence milestones.
+
+## pass-delta-template
+
+You are running Pass δ — the **build-sequence milestones** closing pass — of the business-partners synthesis for {{subject_names}}.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+This pass names WHAT the partnership SHIPS WHEN, anchored in the dasha overlap matrix. NOT generic strategic advice. Specific build-sequence tied to which dasha windows open which operational capacities.
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part IV — Build-Sequence Milestones (Next 5-10 Years)
+
+### 4.1 The 16-20 Year Mature Artifact
+*(By the end of the longest current dasha cycle (~16-20 years out), what visible artifact in the world should this partnership have produced? Anchored in:*
+*— Joint Atmakaraka couplet*
+*— 10th-house cross-overlay signal*
+*— Pearl-to-Pearl coupling*
+*— HD electromagnetic channels' operational signature*
+
+*Be specific about the artifact's mature form — what category of thing, what scale, what archetypal current it carries.)*
+
+### 4.2 The Build Sequence — Year-by-Year for the Next 5-10 Years
+*(For each year of the next 5-10:*
+*— Subject A's Antardasha + Pratyantardasha for that year*
+*— Subject B's Antardasha + Pratyantardasha for that year*
+*— Joint operational signal of that overlap*
+*— What the pair should be DOING in that year (build / scale / consolidate / pivot / ship)*
+*— What the pair should NOT be doing*
+*— The single most important decision-window in that year*
+
+*This is the joint operational calendar. Be specific and actionable.)*
+
+### 4.3 The Three Build-Phases
+*(Group the 5-10 years into 3 phases. Each phase has a name (e.g., "Foundation Phase — through 2027", "Scaling Phase — 2028-2030", "Compound Phase — 2031+"). For each phase, the operational mode + what gets shipped.)*
+
+## Part V — Anti-Dependency for the Joint Operative
+
+### 5.1 Per-Kosha Self-Decoding for Each Partner
+*(For each Kosha layer (body / breath / pattern / discerner / imperishable seed), what should each partner be able to do WITHOUT requiring the other to compensate for their gap — across the new dasha cycle? Anatomically grounded.)*
+
+### 5.2 The Single Sentence
+*(The partnership in one sentence — what it is, what it builds, what makes it irreducible.)*
+
+### 5.3 The Joint AKSHARA Artifact
+*(The imperishable seed of the partnership — what it writes into the world that outlasts the partnership itself.)*
+
+### 5.4 The One Practice
+*(The single operational practice that, if held, lets the pair become a coherent joint instrument — and lets each partner become the kind of operator who could carry the build alone if needed.)*
+
+End Pass δ. The full 4-pass business-partners reading is now complete.
+
+## overlay-rules
+
+For business-partners mode:
+- **Atmakaraka (weight 2.0):** the highest-foregrounded — Atmakaraka comparison is the soul-role architecture of the partnership.
+- **Vimshottari (weight 2.0):** equal foregrounding — the dasha overlap matrix IS the joint operational calendar.
+- **Human Design (weight 1.5):** authority + strategy match is the decision-protocol architecture.
+- **Gene Keys (weight 1.5):** gifts overlay tells you what each partner brings; Pearls couple to make prosperity.
+- **I-Ching (weight 1.5):** partnership hexagram-state is consulted.
+- **Tarot (weight 1.0):** baseline — used in operational-archetype framing, not foregrounded.
+- **Panchanga / Transits (1.0):** baseline.
+- **Biorhythm / Nadabrahman / Face-Reading / Sigil-Forge (< 1.0):** background unless specifically signaling.
+
+**House overlay:**
+- **10 (career / dharma signature):** primary architectural anchor.
+- **11 (joint operative, community):** what the partnership builds and who it reaches.
+- **2 (joint resources, money flow):** the financial substrate.
+- **6 (adversity, daily grind, competitors):** failure-mode mapping locus.
+- **9 (long-distance, expansion, fortune):** the partnership's scale-vector.
+
+## glossary
+
+- **Role-stack** — the three structural operational roles (Vision / Operations / Execution), each tied to a Vedic graha (Jupiter / Saturn / Mars). The role-stack analysis names WHO carries WHICH signal in the partnership.
+- **Vimshottari overlap matrix** — the year-by-year joint dasha calendar showing which Antardasha each subject is in concurrently. The matrix IS the operational calendar.
+- **Dharma-signature alignment** — whether the two subjects' Atmakaraka + 10th-house signatures are complementary, at tension, or reinforcing.
+- **The pair as one joint operative** — the partnership is operative as ONE INSTRUMENT in the operational domain. The 10th house is the architectural anchor, not the 7th.
+
+## interactions
+
+For the interactive HTML output:
+- **Role-stack filter buttons** (Vision / Operations / Execution) — placed near the dyad-arc SVG. Clicking dims content not tagged with the matching `data-role` attribute.
+- **Vimshottari overlap-cell click-to-expand** — each `.vimshottari-cell` span toggles `data-expanded="true"`, revealing the adjacent `.vimshottari-expansion` panel with the year-by-year operational reading.
+- **Hover on dyad-arc resonance threads** → tooltip names the four-way bridge (Atmakaraka × Vimshottari × HD-authority × Gene-Key-gift).
+
+## lessons
+
+*(No autoresearch passes yet. First Pass 6 entry (#56) will land here per the autoresearch contract — variant axis: Pass γ failure-mode specificity; mode-specific judge axis: "operational specificity".)*

--- a/scripts/integratedreading/modes/partner-synastry.md
+++ b/scripts/integratedreading/modes/partner-synastry.md
@@ -1,0 +1,271 @@
+---
+mode: partner-synastry
+subject_count:
+  min: 2
+  max: 2
+roles:
+  - partner-A
+  - partner-B
+target_words:
+  min: 12000
+  max: 15000
+architecture: linear
+pass_plan:
+  - id: alpha
+    title: "Cross-Chart Structural Field"
+    target_words: 3000
+    template: pass-alpha-template
+  - id: beta
+    title: "Pair-Resonance Threads"
+    target_words: 3500
+    template: pass-beta-template
+  - id: gamma
+    title: "Phase-Lock Geometry"
+    target_words: 3500
+    template: pass-gamma-template
+  - id: delta
+    title: "Relational Anti-Dependency Milestones"
+    target_words: 3000
+    template: pass-delta-template
+engine_overlay_weights:
+  tarot: 2.0
+  human-design: 2.0
+  gene-keys: 1.5
+  vimshottari: 1.5
+  i-ching: 1.0
+  panchanga: 0.5
+  nadabrahman: 0.5
+  biorhythm: 0.5
+  face-reading: 0.3
+  sigil-forge: 0.3
+house_overlay: [7, 11, 12, 5, 2]
+bridge_mandates:
+  - "Every major claim must braid four cross-references in the same sentence-flow: Vedic-7th-or-related-house × Tarot-relational-archetype × HD-electromagnetic-channel × dasha-anchor."
+  - "The 9-week (or actual-duration) Mahadasha pivot stagger is PHASE-LOCK GEOMETRY, not coincidence. Decode WHY one transition opens before the other."
+  - "Anti-dependency in Pass δ is per-Kosha-layer self-decoding capacity, NOT relationship-coaching prescriptions. Anatomically grounded only."
+svg_topology: dyad-arc
+---
+
+## pass-alpha-template
+
+You are running Pass α of the 4-pass **partner-synastry** synthesis for {{subject_names}}. This is a romantic / relational reading — two charts as one field, with the 7th-house axis as the primary structural anchor.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+A synastry reading is NOT two solo readings stacked. It is the chart-architectural decoding of WHAT THE PAIR IS WHEN IT IS OPERATIVE AS ONE FIELD. Hold that throughout. The Aletheios + Pichet dyad witnesses ONE composite subject (the pair-as-field), not two adjacent subjects.
+
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES FOR THIS PASS
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+# Partner-Synastry Reading — {{subject_names}}
+
+## Opening — The Pair as a Single Field
+
+*(2-3 paragraphs. Frame the synastry: two bodies, two breath-currents, two pattern-engines woven into a single relational instrument. The 7th-house axis (partnership) is the **literal architectural anchor** of this reading; everything else braids around it. State up-front whether the chart-evidence supports the framing the pair is structurally CONFIGURED for romantic union — and if so, what KIND of union the chart prescribes.)*
+
+## Part I — Cross-Chart Structural Field
+
+### 1.1 Lagna-to-Lagna Disposition
+*(How each Lagna sits relative to the other's chart. Is one Lagna in the other's 7th house? In their Atmakaraka's sign? In their Darakaraka's nakshatra? This is the FOUNDATIONAL cross-chart fact. Don't gloss it.)*
+
+### 1.2 Sun-Moon Cross-Resonance
+*(Subject A's Sun in B's chart, B's Sun in A's. Then both Moons. The Sun-Moon cross-coupling is where the dyad's solar (Vijnanamaya / Cl(3) wisdom) and lunar (Manomaya / Cl(2) pattern) layers interleave. Each cross-placement must surface from at least two systems — Vedic placement + Tarot keyword OR HD center the placement activates.)*
+
+### 1.3 The 7th-House Double-Overlay
+*(Each subject's 7th house, AND what each subject's chart places into the OTHER's 7th house. Specifically: what graha (and which Tarot card it carries) sits in A's 7th-house-as-described-by-B's-chart. The 7th house is the PARTNERSHIP architectural slot; double-overlaying it tells you what each partner is structurally configured to bring to the other's partnership space.)*
+
+### 1.4 Darakaraka × Atmakaraka Cross-Coupling
+*(Subject A's Darakaraka (spouse significator) in B's chart's actual placement — is it well-disposed? Combust? Exalted? Conversely for B's Darakaraka in A's chart. Then the Atmakaraka cross-check: is one subject's Atmakaraka (soul significator) sitting on the other subject's Darakaraka? This is where the soul-significator-of-one literally IS the spouse-significator-of-the-other — the deepest Cl(3) sovereignty match.)*
+
+End Pass α here. Pass β will move into pair-resonance threads (Venus/Mars, navamsa, HD channels, Gene Keys partner spheres).
+
+## pass-beta-template
+
+You are running Pass β of the partner-synastry synthesis for {{subject_names}}. Pass α has established the cross-chart structural field.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part II — Pair-Resonance Threads
+
+### 2.1 Venus-Mars Synastry
+*(The classical romantic-energy pair. Each subject's Venus in the OTHER's chart. Each subject's Mars in the OTHER's chart. Venus-on-Mars and Mars-on-Venus contacts — by sign, house, and nakshatra. Where this carries through: what these placements DO in the body — Venus is the kidneys / pelvic field / aesthetic-receptor net; Mars is the adrenals / suboccipital triangle / executive drive.)*
+
+### 2.2 Navamsa (D-9) Overlay
+*(The Navamsa is the chart of the soul's marriage. Compare both subjects' D-9 Lagnas, 7th lords, and Atmakaraka positions in D-9. Where D-9 reveals truths the D-1 hides about partnership architecture.)*
+
+### 2.3 Upapada Lagna Pair
+*(The Upapada Lagna (UL) is the marriage-significator axis. Each subject's UL — placement, lord, and aspects. Then the cross-check: is one subject's UL in the other's 7th house, or in their Atmakaraka's sign, or in their Darakaraka's nakshatra? UL alignment is where Vedic synastry locates the literal marriage-axis match.)*
+
+### 2.4 HD Electromagnetic Channels
+*(The Human Design channels that are NOT in either chart alone — they only exist in the pair. Name each one: channel number, the two gates involved, what the channel does operationally, and where it lives in the body (which HD center it connects to). Each channel must be paired with a Vedic placement that co-signs it AND a Tarot card OR Gene Key codon that names its archetypal current.)*
+
+### 2.5 Gene Keys SQ↔IQ Programming-Partner Sphere
+*(Each subject's Programming Partner sphere — the Gene Key activated by their Sun's complement. The Programming Partner shows what the chart's soul-self learns through partnership. Cross-couple: does one subject's Programming Partner sphere match the other's Activation, Evolution, or Radiance sphere? This is the Gene Keys' framing of relational pre-configuration.)*
+
+End Pass β. Pass γ will pivot to the phase-lock geometry of the joint Mahadasha transition window.
+
+## pass-gamma-template
+
+You are running Pass γ — the **phase-lock geometry** pass — of the partner-synastry synthesis for {{subject_names}}. Passes α-β have established the structural field + pair-resonance threads.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+This is the keystone PASS. The mode's bridge mandate REQUIRES treating the dasha-pivot stagger as phase-lock geometry, not coincidence. Decode WHY one transition opens before the other. The day-count between pivots is structural data.
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part III — Phase-Lock Geometry
+
+### 3.1 What Each Partner Is Closing
+*(For each subject, the closing Mahadasha lord, what its shadow has been across the relationship arc so far. Be specific about HOW the closing-MD shaped the pair's first chapter.)*
+
+### 3.2 What Each Partner Is Opening
+*(For each, the next Mahadasha lord and its grace-current. The relational implications: what kind of partnership-current does each subject's new MD bring to the pair?)*
+
+### 3.3 The X-Day Stagger Between Pivots — Phase-Lock as Geometry
+*(THE keystone subsection. Compute the day-gap between:*
+*— Subject A's [closing-MD]→[opening-MD] pivot on [date]*
+*— Subject B's [closing-MD]→[opening-MD] pivot on [date]*
+
+*The stagger is X days. NAME IT. Then decode: why this stagger? Why does the field open A's transition first (or B's), and what does that ordering encode about the pair's joint operative? The chart is telling you which subject's grace-cycle INITIATES the dyadic transition. Surface that signal. Anchor in Tarot (which arcanum carries the leading-MD's archetypal current) + HD (which channel goes online when the leading partner enters their new MD) + Vedic (the leading-MD's house lordship in BOTH charts).)*
+
+### 3.4 Transit Overlay for the Shared Window
+*(Outer-planet transits (Jupiter, Saturn, Rahu-Ketu) active across the joint pivot window. Where each transit lands in BOTH charts simultaneously. The transits are the celestial-environmental (Umwelt) overlay that ratifies the dasha-pivot's structural significance.)*
+
+### 3.5 Panchanga State at the Pivot
+*(The day-of-pivot panchanga: tithi, vara (weekday), nakshatra, yoga, karana. Each one carries archetypal current. The Mitwelt (cultural-archetypal) overlay names what kind of day the pair is structurally configured to inaugurate the new MD on.)*
+
+End Pass γ. Pass δ closes with relational anti-dependency.
+
+## pass-delta-template
+
+You are running Pass δ — the **anti-dependency** closing pass — of the partner-synastry synthesis for {{subject_names}}.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+This pass carries the framework's design principle: success = decreasing reliance on the interpreter. Anti-dependency for a romantic pair means: each partner becoming structurally UNABLE TO NEED what the other provides — not by withdrawal, but by integration. The pair matures by each member integrating what the other was carrying.
+
+NO relationship-coaching prescriptions. NO compatibility-product framing. **Per-Kosha-layer self-decoding capacity milestones, anatomically grounded.**
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part IV — Relational Anti-Dependency Milestones
+
+### 4.1 The Body (Annamaya / Cl(0)) — What Each Stops Needing the Other to Regulate
+*(At the somatic layer, what physiological / pranic / postural regulation does each partner currently outsource to the other? Across the new dasha cycle, what should each become able to do alone? Anatomically grounded: liver-zone regulation, vagal-tone regulation, sacral-plexus grounding, etc. Tied to specific chart-architectural signals.)*
+
+### 4.2 The Breath (Pranamaya / Cl(1)) — Pranic Independence Milestones
+*(Where the pair currently phase-locks breath-rhythm. Where each should be able to hold their own pranic state without the other's regulation. Practices the chart-architecture supports.)*
+
+### 4.3 The Pattern Engine (Manomaya / Cl(2)) — Self-Pattern-Recognition
+*(Where each currently uses the other as a mirror to see their own patterns. Across the new MD, each becomes able to read their own patterns without the partner's reflection.)*
+
+### 4.4 The Discerner (Vijnanamaya / Cl(3)) — Independent Discernment
+*(Where each currently consults the other for life-direction decisions. Across the new MD, each comes into their own discriminative wisdom (the literal Vijnanamaya capacity) and can hold their own discernment without requiring the partner's signature.)*
+
+### 4.5 The Imperishable Seed (Anandamaya / Cl(7)) — AKSHARA Independence
+*(Where each currently sources their AKSHARA-seed-current through the partnership. Across the 16-20 year arc, each becomes able to source their imperishable-seed-current directly, without the relational mediation. The pair matures into two complete instruments that are also one field.)*
+
+### 4.6 The Single Sentence
+*(The pair in one sentence — what they are when fully integrated. A structural identity claim the reading has earned.)*
+
+### 4.7 The Joint AKSHARA Artifact
+*(What the pair, across the next 16-20 years of MDs, writes into the world. The imperishable seed of the JOINT operative — its mature form.)*
+
+### 4.8 The One Practice That Ties Both Charts Together
+*(The single practice that, if held faithfully, lets the pair become unable to need the reading.)*
+
+End Pass δ. The full 4-pass partner-synastry reading is now complete.
+
+## overlay-rules
+
+For partner-synastry mode:
+- **Tarot (weight 2.0):** the highest-foregrounded engine — partner-synastry is fundamentally about archetypal-romantic-current, which Tarot's Major Arcana name with the most precision. The Lovers, the Empress, the Hierophant, the Star — these archetypes are not decoration, they are the engine's signal.
+- **Human Design (weight 2.0):** equal foregrounding — HD's electromagnetic channels are the actual STRUCTURAL TOPOLOGY of relational pre-configuration. Channels in the pair that are not in either alone are where the field is generative.
+- **Gene Keys (weight 1.5):** the SQ↔IQ partner-sphere overlay — the literal "what the soul learns through partnership" signal.
+- **Vimshottari (weight 1.5):** the dasha-pivot stagger is structural; the joint operative is timeline-anchored.
+- **I-Ching (weight 1.0):** baseline — the relational hexagram-state is consulted but not foregrounded.
+- **Panchanga (weight 0.5):** background — only foregrounded at the pivot-day (Pass γ § 3.5).
+- **Nadabrahman / Biorhythm / Face-Reading / Sigil-Forge (< 1.0):** present but not foregrounded unless they specifically carry pair-signal.
+
+**House overlay:**
+- **7 (partnership):** primary — the literal architectural anchor for synastry.
+- **11 (joint operative, community):** what the pair produces in the world.
+- **12 (the imperishable, lineage):** what the pair carries into the next phase.
+- **5 (creative offspring including ventures, children):** what the pair generates.
+- **2 (joint resources):** how the pair holds and grows shared resources.
+
+## glossary
+
+- **Phase-lock geometry** — the structural relationship between the two subjects' Mahadasha pivots. The day-count stagger encodes who-leads-whom in the field's transition.
+- **AKSHARA-coupling** — the imperishable-seed coupling at Anandamaya / Cl(7). When both subjects' AKSHARA seeds resonate at the same archetypal frequency, the dyad has a joint imperishable artifact to produce.
+- **Marriage already-already** — the framing that romantic union is a structural fact at the chart-architectural layer, not a public-ritual event. Public ritual CONFIRMS; it does not CONSTITUTE.
+- **The pair-as-field is the instrument** — the reading is of the field, through the dyadic pillar method. The pair is the subject; the dyad is the lens.
+- **Programming Partner sphere (Gene Keys)** — what the chart's soul-self learns through partnership specifically.
+
+## interactions
+
+For the interactive HTML output:
+- **Hover a resonance thread** in the dyad-arc SVG → tooltip names the four-way cross-system bridge it carries: `<channel-name> · Vedic-7th × Tarot-relational × HD-electromagnetic-channel × dasha-anchor`.
+- **Click a dasha-pivot circle** → tooltip shows the pivot date + which subject is transitioning + what archetypal current opens.
+- **Scroll-scrub the phase-lock stagger timeline** (if present as `.phase-lock-scrub` element) → CSS variable `--scrub-progress` animates from 0 to 100 as the section enters view.
+
+## lessons
+
+*(No autoresearch passes yet. First Pass 6 entry (#55) will land here per the autoresearch contract — variant axis: Pass γ phase-lock specificity; mode-specific judge axis: "phase-lock-geometry clarity".)*

--- a/scripts/integratedreading/render/interactions/business-partners.ts
+++ b/scripts/integratedreading/render/interactions/business-partners.ts
@@ -1,0 +1,136 @@
+// ─── Business-Partners mode interactions ──────────────────────────────
+// Layers on top of dyad-arc topology interactions. Adds the role-stack
+// filter (Vision / Operations / Execution) and Vimshottari overlap-cell
+// click-to-expand.
+//
+// Per design doc § 5 — Business-Partners affordances row.
+//
+// P3.4 deliverable. Closes #48.
+
+import type { InteractionModule } from './index.js';
+
+export const businessPartnersModule: InteractionModule = {
+  scrollTimelineCss: `
+/* ════ Business-Partners mode interactions ════════════════════════════ */
+
+/* Role-stack filter buttons — sit alongside the field SVG */
+.canvas.interactive [data-mode="business-partners"] .role-stack-filter {
+  display: flex;
+  gap: 12px;
+  margin: 24px auto;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 9pt;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+.canvas.interactive [data-mode="business-partners"] .role-stack-filter button {
+  background: transparent;
+  border: 1px solid rgba(197,160,23,0.4);
+  color: var(--muted-silver);
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font: inherit;
+  letter-spacing: inherit;
+}
+.canvas.interactive [data-mode="business-partners"] .role-stack-filter button[data-active="true"] {
+  background: rgba(197,160,23,0.1);
+  border-color: var(--sacred-gold);
+  color: var(--sacred-gold);
+}
+.canvas.interactive [data-mode="business-partners"] .role-stack-filter button:hover:not([data-active="true"]) {
+  border-color: var(--coherence-emerald);
+  color: var(--coherence-emerald);
+}
+
+/* When a role-stack filter is active, dim non-matching content */
+.canvas.interactive [data-role-filter="vision"] [data-role]:not([data-role="vision"]),
+.canvas.interactive [data-role-filter="operations"] [data-role]:not([data-role="operations"]),
+.canvas.interactive [data-role-filter="execution"] [data-role]:not([data-role="execution"]) {
+  opacity: 0.25;
+  filter: grayscale(0.6);
+  transition: opacity 0.3s ease, filter 0.3s ease;
+}
+.canvas.interactive [data-role-filter] [data-role][data-role-active] {
+  opacity: 1;
+  filter: none;
+}
+
+/* Vimshottari overlap-cell — visual click affordance */
+.canvas.interactive [data-mode="business-partners"] .vimshottari-cell {
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.3s ease;
+}
+.canvas.interactive [data-mode="business-partners"] .vimshottari-cell:hover {
+  background: rgba(197,160,23,0.08);
+  transform: scale(1.02);
+}
+.canvas.interactive [data-mode="business-partners"] .vimshottari-cell[data-expanded="true"] {
+  background: rgba(16,181,167,0.1);
+  border-left: 3px solid var(--coherence-emerald);
+  padding-left: 12px;
+  margin-left: -15px;
+}
+
+/* The year-by-year expansion panel */
+.canvas.interactive [data-mode="business-partners"] .vimshottari-expansion {
+  display: none;
+  margin-top: 12px;
+  padding: 16px;
+  background: rgba(11,80,251,0.06);
+  border-left: 2px solid var(--flow-indigo);
+  font-family: var(--font-display);
+  font-size: 10.5pt;
+  line-height: 1.5;
+}
+.canvas.interactive [data-mode="business-partners"] .vimshottari-cell[data-expanded="true"] + .vimshottari-expansion {
+  display: block;
+}
+`,
+
+  gsapTimeline: `
+// Business-Partners — no GSAP timelines beyond the dyad-arc base.
+// All interactive affordances are handler-driven (filters + click-expand).
+`,
+
+  eventHandlers: `
+// Business-Partners — role-stack filter + Vimshottari cell click-expand
+(function() {
+  var canvas = document.querySelector('.canvas.interactive[data-mode="business-partners"]');
+  if (!canvas) return;
+
+  // ── Role-stack filter ───────────────────────────────────────────
+  var buttons = canvas.querySelectorAll('.role-stack-filter button');
+  buttons.forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var role = btn.getAttribute('data-role');
+      var currentlyActive = btn.getAttribute('data-active') === 'true';
+      buttons.forEach(function(b) { b.setAttribute('data-active', 'false'); });
+      if (currentlyActive) {
+        canvas.removeAttribute('data-role-filter');
+      } else {
+        btn.setAttribute('data-active', 'true');
+        canvas.setAttribute('data-role-filter', role || '');
+      }
+      // Mark matching elements as active for re-emphasis
+      canvas.querySelectorAll('[data-role]').forEach(function(el) {
+        if (el.getAttribute('data-role') === role && !currentlyActive) {
+          el.setAttribute('data-role-active', 'true');
+        } else {
+          el.removeAttribute('data-role-active');
+        }
+      });
+    });
+  });
+
+  // ── Vimshottari overlap-cell click-to-expand ────────────────────
+  canvas.querySelectorAll('.vimshottari-cell').forEach(function(cell) {
+    cell.addEventListener('click', function() {
+      var expanded = cell.getAttribute('data-expanded') === 'true';
+      cell.setAttribute('data-expanded', expanded ? 'false' : 'true');
+    });
+  });
+})();
+`,
+};

--- a/scripts/integratedreading/render/interactions/index.ts
+++ b/scripts/integratedreading/render/interactions/index.ts
@@ -206,6 +206,30 @@ export const INTERACTION_MODULES: Record<TopologyKey, InteractionModule> = {
 };
 
 // ────────────────────────────────────────────────────────────────────────
+// Mode-keyed interactions (layered ON TOP of topology-keyed)
+//
+// Different modes can share an SVG topology but want different
+// affordances. E.g., both `partner-synastry` and `composite-dyad` use
+// `dyad-arc`, but synastry needs the four-way-bridge tooltip while the
+// generic composite uses the basic thread pulse. Mode-keyed modules
+// declare additional CSS/JS that gets COMPOSED with the topology base.
+//
+// Authoring contract:
+//   - mode-keyed modules layer ON TOP of topology-keyed modules
+//   - they do NOT replace topology modules
+//   - per-mode css/gsap/handlers are appended after topology equivalents
+//   - look up by mode name first, fall back to topology if no mode entry
+// ────────────────────────────────────────────────────────────────────────
+
+import { partnerSynastryModule } from './partner-synastry.js';
+import { businessPartnersModule } from './business-partners.js';
+
+export const MODE_INTERACTION_MODULES: Record<string, InteractionModule> = {
+  'partner-synastry': partnerSynastryModule,
+  'business-partners': businessPartnersModule,
+};
+
+// ────────────────────────────────────────────────────────────────────────
 // Shared base — scroll-narrative scaffold CSS + JS that EVERY interactive
 // page gets, regardless of topology. This drives the cover fade-in,
 // sticky TOC rail, plate scroll-snap, and per-Part sticky-viz columns.
@@ -482,25 +506,35 @@ export const BASE_INTERACTIVE_JS = `
 })();
 `;
 
-/** Convenience — assemble all three layers (CSS / GSAP / handlers) for a topology. */
-export function buildInteractionPayload(topology: string): {
+/**
+ * Convenience — assemble all three layers (CSS / GSAP / handlers).
+ *
+ * Composition order (bottom → top):
+ *   1. BASE_SCROLL_NARRATIVE_CSS + BASE_INTERACTIVE_JS (always)
+ *   2. Topology-keyed module (e.g., dyad-arc thread pulse)
+ *   3. Mode-keyed module if `mode` provided (e.g., synastry bridge tooltip)
+ *
+ * Pass only `topology` for the legacy single-arg call. Pass both for
+ * mode-aware composition.
+ */
+export function buildInteractionPayload(topology: string, mode?: string): {
   css: string;
   gsap: string;
   handlers: string;
 } {
-  const mod = INTERACTION_MODULES[topology as TopologyKey];
-  if (!mod) {
+  const topoMod = INTERACTION_MODULES[topology as TopologyKey];
+  if (!topoMod) {
     return {
       css: `/* unknown topology '${topology}' — no interaction module */`,
       gsap: `// unknown topology '${topology}'`,
       handlers: `// unknown topology '${topology}'`,
     };
   }
-  return {
-    css: BASE_SCROLL_NARRATIVE_CSS + '\n' + mod.scrollTimelineCss,
-    gsap: mod.gsapTimeline,
-    handlers: BASE_INTERACTIVE_JS + '\n' + mod.eventHandlers,
-  };
+  const modeMod = mode ? MODE_INTERACTION_MODULES[mode] : undefined;
+  const css = [BASE_SCROLL_NARRATIVE_CSS, topoMod.scrollTimelineCss, modeMod?.scrollTimelineCss].filter(Boolean).join('\n');
+  const gsap = [topoMod.gsapTimeline, modeMod?.gsapTimeline].filter(Boolean).join('\n');
+  const handlers = [BASE_INTERACTIVE_JS, topoMod.eventHandlers, modeMod?.eventHandlers].filter(Boolean).join('\n');
+  return { css, gsap, handlers };
 }
 
 export const GSAP_CDN = 'https://cdnjs.cloudflare.com/ajax/libs/gsap/3.12.5/gsap.min.js';

--- a/scripts/integratedreading/render/interactions/partner-synastry.ts
+++ b/scripts/integratedreading/render/interactions/partner-synastry.ts
@@ -1,0 +1,114 @@
+// ─── Partner-Synastry mode interactions ──────────────────────────────
+// Layers on top of dyad-arc topology interactions. Adds the four-way-
+// bridge tooltip (Vedic-7th × Tarot × HD-channel × dasha-anchor) and
+// scroll-scrub on the dasha-stagger timeline.
+//
+// Per design doc § 5 — Partner-Synastry affordances row of the
+// "Per-mode interactive affordances" table.
+//
+// P3.2 deliverable. Closes #46.
+
+import type { InteractionModule } from './index.js';
+
+export const partnerSynastryModule: InteractionModule = {
+  scrollTimelineCss: `
+/* ════ Partner-Synastry mode interactions ═════════════════════════════ */
+
+/* Resonance threads carry the four-way bridge — show pointer cursor + soft
+ * pulse on hover. The tooltip itself is rendered by the JS handler. */
+.canvas.interactive .viz svg path[stroke^="url(#dyad-thread"] {
+  cursor: help;
+}
+.canvas.interactive .viz svg path[stroke^="url(#dyad-thread"]:hover {
+  stroke-opacity: 1 !important;
+  filter: drop-shadow(0 0 8px var(--sacred-gold));
+}
+
+/* Dasha-pivot markers (small circles) — interactive emphasis on hover */
+.canvas.interactive .viz svg circle[r="4"] {
+  transition: r 0.3s ease, filter 0.3s ease;
+  cursor: pointer;
+}
+.canvas.interactive .viz svg circle[r="4"]:hover {
+  r: 6;
+  filter: drop-shadow(0 0 8px currentColor);
+}
+
+/* Phase-lock stagger timeline — a horizontal line segment we want to
+ * scrub on scroll. Targeted via data-attribute the orchestrator sets. */
+.canvas.interactive [data-mode="partner-synastry"] .phase-lock-scrub {
+  --scrub-progress: 0;
+  background: linear-gradient(90deg,
+    var(--coherence-emerald) 0%,
+    var(--sacred-gold) calc(var(--scrub-progress) * 1%),
+    rgba(197,160,23,0.12) calc(var(--scrub-progress) * 1%),
+    rgba(197,160,23,0.12) 100%);
+  height: 3px;
+  margin: 24px 0;
+  position: relative;
+}
+
+@supports (animation-timeline: scroll()) {
+  .canvas.interactive [data-mode="partner-synastry"] .phase-lock-scrub {
+    animation: phase-lock-fill linear both;
+    animation-timeline: scroll(root);
+    animation-range: 30% 70%;
+  }
+  @keyframes phase-lock-fill {
+    from { --scrub-progress: 0; }
+    to   { --scrub-progress: 100; }
+  }
+}
+`,
+
+  gsapTimeline: `
+// Partner-Synastry — additional scroll-triggered: pivot-circle pulse on enter
+if (typeof gsap !== 'undefined' && typeof ScrollTrigger !== 'undefined') {
+  document.querySelectorAll('.canvas.interactive .viz svg circle[r="4"]').forEach(function(c) {
+    gsap.fromTo(c, { scale: 0.5, opacity: 0 }, {
+      scale: 1, opacity: 1, duration: 0.6, ease: 'back.out(2)',
+      transformOrigin: 'center', transformBox: 'fill-box',
+      scrollTrigger: { trigger: c, start: 'top 85%', toggleActions: 'play none none reverse' },
+    });
+  });
+}
+`,
+
+  eventHandlers: `
+// Partner-Synastry — hover-thread tooltip names the four-way bridge.
+// The thread's text-label SVG sibling carries the channel name; we
+// build a richer tooltip combining that with the mode's bridge mandate.
+(function() {
+  // Bridge mandate text — pulled from data-bridge-mandate on body root if set.
+  var mandate = document.body.dataset.bridgeMandate ||
+    'Vedic-7th × Tarot-relational × HD-electromagnetic-channel × dasha-anchor';
+
+  document.querySelectorAll('.canvas.interactive .viz svg path[stroke^="url(#dyad-thread"]').forEach(function(thread) {
+    // Find the adjacent text element that names the channel
+    var label = thread.parentElement.querySelector('text[font-family*="SF Mono"][font-weight="600"]');
+    var channelName = label ? (label.textContent || '').trim() : 'electromagnetic channel';
+    var tooltipText = channelName + ' · ' + mandate;
+    thread.setAttribute('data-bridge', tooltipText);
+    thread.addEventListener('mouseenter', function(e) {
+      if (typeof window.showBridgeTooltip === 'function') {
+        window.showBridgeTooltip(e, tooltipText);
+      }
+    });
+    thread.addEventListener('mouseleave', function() {
+      if (typeof window.hideBridgeTooltip === 'function') window.hideBridgeTooltip();
+    });
+  });
+
+  // Pivot markers: click cycles through Mahadasha-pivot context tooltip
+  document.querySelectorAll('.canvas.interactive .viz svg circle[r="4"]').forEach(function(c) {
+    c.addEventListener('click', function(e) {
+      var label = c.parentElement.querySelector('text[font-style="italic"]');
+      if (label && typeof window.showBridgeTooltip === 'function') {
+        window.showBridgeTooltip(e, label.textContent || 'Mahadasha pivot');
+        setTimeout(function() { if (window.hideBridgeTooltip) window.hideBridgeTooltip(); }, 3000);
+      }
+    });
+  });
+})();
+`,
+};

--- a/scripts/integratedreading/render/templates.ts
+++ b/scripts/integratedreading/render/templates.ts
@@ -280,6 +280,12 @@ export function renderInteractiveHTMLPage(opts: {
   cover: CoverData;
   topology: string;
   parts: PartBlock[];
+  /** Mode name (e.g. "partner-synastry") — layers mode-keyed interactions
+   *  on top of topology-keyed interactions when provided. */
+  mode?: string;
+  /** Mode-specific bridge mandate, embedded as data-attr for interaction
+   *  modules (e.g. synastry tooltip composition). */
+  bridge_mandate?: string;
   opening_html?: string;
   fig_index_html?: string;
   is_composite?: boolean;
@@ -294,8 +300,8 @@ export function renderInteractiveHTMLPage(opts: {
     ? `<div class="cover-svg-wrap">${opts.cover.cover_mandala_svg}</div>`
     : '';
 
-  // Topology-specific interaction layer (inlined)
-  const interaction = buildInteractionPayload(opts.topology);
+  // Topology + mode-keyed interaction layer (inlined)
+  const interaction = buildInteractionPayload(opts.topology, opts.mode);
 
   // TOC rail entries — generated from parts list
   const tocRailHtml = `
@@ -338,8 +344,8 @@ ${STYLES}
 ${interaction.css}
 </style>
 </head>
-<body>
-<div class="canvas interactive">
+<body${opts.bridge_mandate ? ` data-bridge-mandate="${opts.bridge_mandate.replace(/"/g, '&quot;')}"` : ''}>
+<div class="canvas interactive"${opts.mode ? ` data-mode="${opts.mode}"` : ''}>
   <!-- ───────────── COVER PAGE ───────────── -->
   <section class="cover">
     <header>

--- a/tests/relational-modes.test.ts
+++ b/tests/relational-modes.test.ts
@@ -1,0 +1,250 @@
+// ─── P3 — Partner-Synastry + Business-Partners mode tests ──────────────
+// Covers #45 (partner-synastry mode doc), #46 (synastry interaction),
+// #47 (business-partners mode doc), #48 (business interaction).
+// Also the cross-cutting mode-keyed lookup in buildInteractionPayload.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+import { parseModeDoc } from '../scripts/integratedreading/modes/parser.js';
+import {
+  MODE_INTERACTION_MODULES,
+  buildInteractionPayload,
+  BASE_SCROLL_NARRATIVE_CSS,
+} from '../scripts/integratedreading/render/interactions/index.js';
+import { renderInteractiveHTMLPage, type PartBlock } from '../scripts/integratedreading/render/templates.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// Mode docs parse cleanly
+// ────────────────────────────────────────────────────────────────────────
+
+describe('Partner-Synastry mode doc (P3.1)', () => {
+  const path = resolve('scripts/integratedreading/modes/partner-synastry.md');
+
+  it('parses without errors', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.mode, 'partner-synastry');
+  });
+
+  it('declares 4 passes with correct ids', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.pass_plan.length, 4);
+    assert.deepEqual(doc.frontmatter.pass_plan.map((p) => p.id), ['alpha', 'beta', 'gamma', 'delta']);
+  });
+
+  it('targets 12-15k words across 4 passes', () => {
+    const doc = parseModeDoc(path);
+    const sum = doc.frontmatter.pass_plan.reduce((s, p) => s + p.target_words, 0);
+    assert.ok(sum >= 12000, `pass_plan total = ${sum}, expected >= 12000`);
+    assert.ok(sum <= 15000, `pass_plan total = ${sum}, expected <= 15000`);
+  });
+
+  it('foregrounds tarot + human-design at weight >= 2.0', () => {
+    const doc = parseModeDoc(path);
+    assert.ok(doc.frontmatter.engine_overlay_weights.tarot >= 2.0);
+    assert.ok(doc.frontmatter.engine_overlay_weights['human-design'] >= 2.0);
+  });
+
+  it('declares house_overlay includes 7 (partnership)', () => {
+    const doc = parseModeDoc(path);
+    assert.ok(doc.frontmatter.house_overlay.includes(7));
+  });
+
+  it('declares svg_topology: dyad-arc', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.svg_topology, 'dyad-arc');
+  });
+
+  it('has 4-way bridge mandate naming all four cross-systems', () => {
+    const doc = parseModeDoc(path);
+    const m = doc.frontmatter.bridge_mandates[0];
+    assert.match(m, /Vedic/);
+    assert.match(m, /Tarot/);
+    assert.match(m, /HD|Human Design/);
+    assert.match(m, /dasha/);
+  });
+
+  it('every pass template resolves to a body section', () => {
+    const doc = parseModeDoc(path);
+    for (const pass of doc.frontmatter.pass_plan) {
+      assert.ok(doc.sections[pass.template], `missing section: ${pass.template}`);
+    }
+  });
+});
+
+describe('Business-Partners mode doc (P3.3)', () => {
+  const path = resolve('scripts/integratedreading/modes/business-partners.md');
+
+  it('parses without errors', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.mode, 'business-partners');
+  });
+
+  it('declares 4 passes', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.pass_plan.length, 4);
+  });
+
+  it('targets 12-15k words', () => {
+    const doc = parseModeDoc(path);
+    const sum = doc.frontmatter.pass_plan.reduce((s, p) => s + p.target_words, 0);
+    assert.ok(sum >= 12000 && sum <= 15000);
+  });
+
+  it('foregrounds atmakaraka + vimshottari at weight >= 2.0', () => {
+    const doc = parseModeDoc(path);
+    assert.ok(doc.frontmatter.engine_overlay_weights.atmakaraka >= 2.0);
+    assert.ok(doc.frontmatter.engine_overlay_weights.vimshottari >= 2.0);
+  });
+
+  it('declares house_overlay includes 10 (career/dharma)', () => {
+    const doc = parseModeDoc(path);
+    assert.ok(doc.frontmatter.house_overlay.includes(10));
+  });
+
+  it('has bridge mandate naming Atmakaraka + Vimshottari + HD + Gene-Key-gift', () => {
+    const doc = parseModeDoc(path);
+    const m = doc.frontmatter.bridge_mandates[0];
+    assert.match(m, /Atmakaraka/);
+    assert.match(m, /Vimshottari/);
+    assert.match(m, /HD|authority/);
+    assert.match(m, /Gene[ -]Key/);
+  });
+
+  it('emphasizes operational specificity in its mandate', () => {
+    const doc = parseModeDoc(path);
+    const allMandates = doc.frontmatter.bridge_mandates.join(' ');
+    assert.match(allMandates, /operational|specific|SHIPS/i);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Mode-keyed interaction modules (P3.2 + P3.4)
+// ────────────────────────────────────────────────────────────────────────
+
+describe('MODE_INTERACTION_MODULES registry', () => {
+  it('registers partner-synastry and business-partners', () => {
+    assert.ok(MODE_INTERACTION_MODULES['partner-synastry']);
+    assert.ok(MODE_INTERACTION_MODULES['business-partners']);
+  });
+
+  it('each mode module has the 3 required layers', () => {
+    for (const k of Object.keys(MODE_INTERACTION_MODULES)) {
+      const m = MODE_INTERACTION_MODULES[k];
+      assert.equal(typeof m.scrollTimelineCss, 'string', `${k}.scrollTimelineCss`);
+      assert.equal(typeof m.gsapTimeline, 'string', `${k}.gsapTimeline`);
+      assert.equal(typeof m.eventHandlers, 'string', `${k}.eventHandlers`);
+    }
+  });
+
+  it('partner-synastry adds bridge-tooltip behavior beyond dyad-arc base', () => {
+    const m = MODE_INTERACTION_MODULES['partner-synastry'];
+    assert.match(m.eventHandlers, /Bridge mandate|showBridgeTooltip/);
+    assert.match(m.scrollTimelineCss, /partner-synastry|Phase-Lock|phase-lock|cursor:\s*help/);
+  });
+
+  it('business-partners adds role-stack filter + vimshottari-cell expansion', () => {
+    const m = MODE_INTERACTION_MODULES['business-partners'];
+    assert.match(m.eventHandlers, /role-stack|data-role/);
+    assert.match(m.eventHandlers, /vimshottari-cell|data-expanded/);
+  });
+});
+
+describe('buildInteractionPayload — mode-keyed composition', () => {
+  it('composes BASE + topology when no mode given', () => {
+    const payload = buildInteractionPayload('dyad-arc');
+    assert.ok(payload.css.includes('Scroll-Narrative Scaffold'));
+    assert.ok(!payload.css.includes('Partner-Synastry mode interactions'));
+  });
+
+  it('composes BASE + topology + MODE when mode given', () => {
+    const payload = buildInteractionPayload('dyad-arc', 'partner-synastry');
+    assert.ok(payload.css.includes('Scroll-Narrative Scaffold'));
+    assert.ok(payload.css.includes('Partner-Synastry mode interactions'));
+    assert.match(payload.handlers, /showBridgeTooltip/);
+  });
+
+  it('mode-keyed CSS comes AFTER topology-keyed CSS', () => {
+    const payload = buildInteractionPayload('dyad-arc', 'partner-synastry');
+    const baseIdx = payload.css.indexOf('Scroll-Narrative Scaffold');
+    const modeIdx = payload.css.indexOf('Partner-Synastry mode interactions');
+    assert.ok(baseIdx >= 0 && modeIdx > baseIdx, 'mode CSS must be appended after topology CSS');
+  });
+
+  it('falls back gracefully when mode unknown', () => {
+    const payload = buildInteractionPayload('dyad-arc', 'unknown-mode');
+    assert.ok(payload.css.includes('Scroll-Narrative Scaffold'));
+    // No mode CSS appended
+    assert.ok(!payload.css.includes('Partner-Synastry'));
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// renderInteractiveHTMLPage — mode + bridge_mandate plumbing
+// ────────────────────────────────────────────────────────────────────────
+
+describe('renderInteractiveHTMLPage — mode wiring', () => {
+  const samplePart: PartBlock = {
+    partNum: 1, romanNumeral: 'I', title: 'X', contentHtml: '<p>y</p>',
+  };
+
+  it('emits data-mode attribute on .canvas.interactive when mode given', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'A × B', birth_date: '2026-01-01' },
+      topology: 'dyad-arc',
+      mode: 'partner-synastry',
+      parts: [samplePart],
+    });
+    assert.match(html, /class="canvas interactive" data-mode="partner-synastry"/);
+  });
+
+  it('emits data-bridge-mandate attribute on <body> when provided', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'A × B', birth_date: '2026-01-01' },
+      topology: 'dyad-arc',
+      mode: 'partner-synastry',
+      bridge_mandate: 'Vedic-7th × Tarot × HD × dasha',
+      parts: [samplePart],
+    });
+    assert.match(html, /data-bridge-mandate="Vedic-7th × Tarot × HD × dasha"/);
+  });
+
+  it('inlines the mode-specific interaction module', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'A × B', birth_date: '2026-01-01' },
+      topology: 'dyad-arc',
+      mode: 'business-partners',
+      parts: [samplePart],
+    });
+    assert.match(html, /Business-Partners mode interactions/);
+    assert.match(html, /role-stack-filter/);
+  });
+
+  it('does NOT inline mode CSS when mode is omitted (back-compat with composite-dyad/-triad)', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'A × B', birth_date: '2026-01-01' },
+      topology: 'dyad-arc',
+      // no `mode`
+      parts: [samplePart],
+    });
+    assert.ok(!html.includes('Partner-Synastry mode interactions'));
+    assert.ok(!html.includes('Business-Partners mode interactions'));
+  });
+
+  it('escapes quotes in bridge_mandate', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'A × B', birth_date: '2026-01-01' },
+      topology: 'dyad-arc',
+      mode: 'partner-synastry',
+      bridge_mandate: 'A "quoted" mandate',
+      parts: [samplePart],
+    });
+    assert.match(html, /data-bridge-mandate="A &quot;quoted&quot; mandate"/);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 3 — two new reading modes shipped entirely as Markdown mode docs + per-mode interaction modules. **Zero orchestrator code changes beyond a 2-line wiring** — proof that the P0-P2 substrate works as designed (mode-as-data).

## Closes
- Closes #45 — P3.1 partner-synastry.md
- Closes #46 — P3.2 Partner-Synastry interaction module
- Closes #47 — P3.3 business-partners.md
- Closes #48 — P3.4 Business-Partners interaction module

## What changed

**Partner-Synastry** (romantic/relational, 7th-house anchored, 4-pass 12-15k)
- α Cross-Chart Structural Field · β Pair-Resonance Threads · γ Phase-Lock Geometry (keystone) · δ Relational Anti-Dependency Milestones
- Overlays: tarot 2.0, HD 2.0, gene-keys 1.5, vimshottari 1.5 · Houses [7,11,12,5,2]
- Bridge mandate: Vedic-7th × Tarot-relational × HD-electromagnetic-channel × dasha-anchor
- Interaction: hover-thread tooltip names the four-way bridge; pivot-circle click reveals Mahadasha context

**Business-Partners** (operational, 10th-house anchored, 4-pass 12-15k)
- α Dharma-Signature Alignment · β Joint-Operative Field · γ Friction & Failure-Mode Mapping · δ Build-Sequence Milestones
- Overlays: atmakaraka 2.0, vimshottari 2.0, HD 1.5, gene-keys 1.5, i-ching 1.5 · Houses [10,11,2,6,9]
- Bridge mandate: Atmakaraka-role × Vimshottari-overlap × HD-authority × Gene-Key-gift
- Interaction: role-stack filter (Vision/Ops/Execution) + Vimshottari overlap-cell click-to-expand

**Framework extension** (cross-cutting, enables future modes for free)
- \`MODE_INTERACTION_MODULES\` registry — mode-keyed interactions layered on top of topology-keyed
- \`buildInteractionPayload(topology, mode?)\` — composes BASE + topology + mode
- \`renderInteractiveHTMLPage\` accepts \`mode\` + \`bridge_mandate\` — emits data-attributes for the JS layer
- Orchestrator passes both through automatically

## Verification
- 70/70 tests pass (28 new + 42 existing)
- Both new modes dry-run cleanly on real fixtures
- composite-dyad + composite-triad still dry-run (no regressions)

## Test plan
- [ ] \`npm test\` → 70/70 pass
- [ ] \`integratedreading-mode.ts --mode partner-synastry --subjects-dir <dir> --output-dir <dir> --dry-run\` → loads cleanly
- [ ] Same for business-partners
- [ ] Full live run on either mode produces 12-15k word reading
- [ ] Open HTML artifact — verify hover tooltips (synastry) / role-stack filter (business) work

🤖 Generated with [Claude Code](https://claude.com/claude-code)