### PR TITLE
feat(integratedreading): P4 Family-Penta mode + pentagon SVG topology

### DIFF
--- a/scripts/integratedreading-mode.ts
+++ b/scripts/integratedreading-mode.ts
@@ -574,6 +574,8 @@ async function main() {
       svgString = renderByTopology(topology, buildDyadSvgData(subjects), { width: 640 });
     } else if (topology === 'triad-triangle' && subjects.length === 3) {
       svgString = renderByTopology(topology, buildTriadSvgData(subjects), { width: 720 });
+    } else if (topology === 'pentagon' && subjects.length === 5) {
+      svgString = renderByTopology(topology, buildPentaSvgData(subjects), { width: 720 });
     } else {
       console.log(`  (SVG topology '${topology}' renderer not yet available — emitting placeholder)`);
     }
@@ -704,6 +706,29 @@ function buildTriadSvgData(subjects: SubjectConfig[]) {
       next_mahadasha_lord: s.mahadasha?.next_lord,
       next_mahadasha_iso: s.mahadasha?.current_ends_iso,
     })),
+    shared_keys: [],
+  };
+}
+
+function buildPentaSvgData(subjects: SubjectConfig[]) {
+  // Convention: positions 1+2 = roots (warm tones), 3-5 = branches (cool tones)
+  const colors = [
+    '#F0EDE3', // root-1: parchment (warm)
+    '#C5A017', // root-2: sacred-gold (warm)
+    '#10B5A7', // branch-1: coherence-emerald
+    '#0B50FB', // branch-2: flow-indigo
+    '#2D0050', // branch-3: witness-violet
+  ];
+  return {
+    subjects: subjects.slice(0, 5).map((s, i) => ({
+      name: s.subject,
+      arc_color: colors[i],
+      role: i < 2 ? 'root' as const : 'branch' as const,
+      current_mahadasha_lord: s.mahadasha?.current_lord,
+      next_mahadasha_lord: s.mahadasha?.next_lord,
+      next_mahadasha_iso: s.mahadasha?.current_ends_iso,
+    })) as [any, any, any, any, any],
+    dominant_pairs: [[0, 1]] as Array<[number, number]>,  // root-pair always dominant
     shared_keys: [],
   };
 }

--- a/scripts/integratedreading/modes/family-penta.md
+++ b/scripts/integratedreading/modes/family-penta.md
@@ -1,0 +1,343 @@
+---
+mode: family-penta
+subject_count:
+  min: 5
+  max: 5
+roles:
+  - root-1
+  - root-2
+  - branch-1
+  - branch-2
+  - branch-3
+target_words:
+  min: 13000
+  max: 15000
+architecture: linear
+pass_plan:
+  - id: alpha
+    title: "Lineage Karma Field"
+    target_words: 3000
+    template: pass-alpha-template
+  - id: beta
+    title: "Roots — The Two Anchors"
+    target_words: 2500
+    template: pass-beta-template
+  - id: gamma
+    title: "Branches — What Each Carries"
+    target_words: 2500
+    template: pass-gamma-template
+  - id: delta
+    title: "Joint Operative + Shadow"
+    target_words: 3500
+    template: pass-delta-template
+  - id: epsilon
+    title: "Generational Anti-Dependency"
+    target_words: 3000
+    template: pass-epsilon-template
+engine_overlay_weights:
+  vimshottari: 2.0
+  panchanga: 1.5
+  tarot: 1.5
+  gene-keys: 1.5
+  human-design: 1.0
+  nadabrahman: 1.0
+  i-ching: 0.5
+  transits: 1.0
+  biorhythm: 0.5
+  face-reading: 0.3
+  sigil-forge: 0.3
+house_overlay: [4, 9, 12, 5, 2, 3]
+bridge_mandates:
+  - "Every major claim must braid four cross-references: Lineage-house (4/9/12) × Pitru-karaka × Generational-nakshatra-pattern × Gene-Key-sphere-of-purpose."
+  - "The root-pair (vertices 1+2) is the field's anchor; branches inherit, contribute, and depart from this anchor. Every claim about a branch must triangulate against the root-pair's signature."
+  - "Anti-dependency for a family field means each member becoming structurally UNABLE TO NEED what the others provide — the family matures by structurally completing its own dispersal."
+svg_topology: pentagon
+---
+
+## pass-alpha-template
+
+You are running Pass α of the 5-pass **family-penta** synthesis for {{subject_names}}.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+A family-penta reading is NOT five solo readings stacked. It is the chart-architectural decoding of WHAT THE FAMILY IS WHEN IT IS OPERATIVE AS ONE FIELD. The lineage current — Pitru karaka, 4th/9th/12th house axis, generational nakshatra resonance — is the literal architectural anchor. Hold that throughout.
+
+Convention: positions 1+2 are the **roots** (typically parents or anchoring elders); positions 3-5 are the **branches** (typically children, but the convention extends to any 5-member kinship configuration where two members anchor the field and three inherit/contribute).
+
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES FOR THIS PASS
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+# Family-Penta Reading — {{subject_names}}
+
+## Opening — The Family as a Single Lineage Field
+
+*(2-3 paragraphs. Frame the family-penta as a kinship-architectural instrument: five bodies, five breath-currents, five pattern-engines woven into a single lineage-field. The lineage-house axis (4 / 9 / 12) is the literal architectural anchor. State up-front whether the chart-evidence supports treating these five as one operative field — and if so, what KIND of lineage-current the chart-architecture prescribes.)*
+
+## Part I — The Lineage Karma Field
+
+### 1.1 The 4th / 9th / 12th House Cross-Overlay Across All Five Charts
+*(For each of the 5 subjects, the 4th house (root, mother, ancestral home), the 9th house (dharma, father, ancestral wisdom), and the 12th house (the imperishable, lineage karma, what comes through from before). Then the cross-overlay table: where does each subject's chart place into the others' lineage-house positions? This is where the family's karma is structurally encoded.)*
+
+### 1.2 Pitru Karaka Comparison Across All Five
+*(For each subject, the Pitru karaka (the planet representing the paternal/ancestral lineage). For Vedic sidereal: in Jaimini, the 4th-from-Atmakaraka karaka. State which graha carries Pitru karaka for each member. Then the cross-analysis: do any two subjects share Pitru karaka? Where does one's Pitru karaka graha sit in another's chart? This is the literal soul-significator of the LINEAGE that runs through all five.)*
+
+### 1.3 Moon-Condition Cross-Resonance
+*(Each subject's Moon — sign, nakshatra, condition. The Moon is the matra (mother) karaka and the literal Manomaya / Cl(2) pattern-engine signature. Moon-cross-resonance across five charts shows where the family's emotional-mental field is in sync vs where it has built-in friction.)*
+
+### 1.4 Generational Nakshatra Pattern
+*(The 27 nakshatras cycle in a specific archetypal order. When 2-3 family members share a nakshatra or its pada-pair, the family carries a generational nakshatra signature. Identify it across the five subjects. Where the same nakshatra appears in 3+ members, that's a lineage-current MARKER — name it.)*
+
+### 1.5 The Single Sentence — What This Family Is at the Lineage Layer
+*(One sentence — the family-as-field's lineage-current identity. The reading earns this in the remaining four passes; state the working hypothesis here.)*
+
+End Pass α. Pass β will move into the root-pair as the anchoring couplet.
+
+## pass-beta-template
+
+You are running Pass β of the family-penta synthesis for {{subject_names}}. Pass α has established the lineage karma field.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+This pass focuses on the ROOT-PAIR (subjects in positions 1+2) — the field's anchoring couplet. Branches (3-5) get Pass γ.
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part II — The Root Field
+
+### 2.1 The Joint Atmakaraka Dynamic of the Roots
+*(For root-1 and root-2: each Atmakaraka, their respective archetypal-soul-signatures. Then the JOINT analysis: are the two Atmakarakas complementary, at tension, or reinforcing? The root-pair's joint Atmakaraka determines what soul-current the family-field is anchored to. The branches inherit FROM this anchor.)*
+
+### 2.2 The Roots' Dasha Overlap as the Root-Field's Operational Calendar
+*(The Vimshottari Mahadasha-Antardasha calendars of root-1 and root-2 plotted against each other. Where the roots' dashas overlap, the family-field is most operative. Where they diverge, the field tilts toward whichever root is in expansion phase. Walk through the next 5-10 years specifically.)*
+
+### 2.3 The Root-Pair as One Composite Subject
+*(Treat root-1 + root-2 AS A DYAD reading mini-instance. Just enough to surface:*
+*— Their joint Lagna-disposition*
+*— Their Moon-Sun cross-resonance*
+*— Their 7th-house overlay (do they have a strong romantic-partnership cross-coupling, or are they primarily co-anchors of the lineage rather than a romantic dyad?)*
+
+*The root-pair is the dyad inside the penta. Its quality determines the field's structural stability.)*
+
+### 2.4 What the Roots Inherited
+*(Each root's own lineage-houses (4/9/12) — what each root brought IN from THEIR own parents/lineage. The penta-field is layered with the lineage above this generation. Name what the roots received that they're now carrying forward through the branches.)*
+
+End Pass β. Pass γ moves to the three branches.
+
+## pass-gamma-template
+
+You are running Pass γ of the family-penta synthesis for {{subject_names}}. Passes α-β have established the lineage field + root-pair anchor.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+This pass reads the three BRANCHES (subjects in positions 3, 4, 5) — what each carries from the root-field, what each contributes that the roots don't carry alone, where each branch is structurally configured to depart from the root-field.
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part III — The Branches
+
+Mark each branch sub-section with `<section data-member="N">` (where N = 2, 3, 4 for branches 1-3) so the interactive layer can scroll-to-spotlight from the vertex click.
+
+### 3.1 Branch 1 (position 3): What [name] Carries from the Root-Field
+*(For this branch, anchored in their chart:*
+*— Their nakshatra-resonance back to the roots' nakshatras (do they share a root's birth-nakshatra? Padas? Lord?)*
+*— Their Atmakaraka in relation to the joint root-Atmakaraka — same? complementary? departing?*
+*— Their 4th house (mother) — what graha is there, how does it relate to root-2's signature? Their 9th house (father) — what graha, relation to root-1's signature?*
+*— What this branch is structurally configured to INHERIT.*
+*— What this branch is structurally configured to CONTRIBUTE that the roots don't carry alone.*
+*— Where this branch is configured to DEPART from the root-field's signature (autonomous direction).*)*
+
+### 3.2 Branch 2 (position 4): What [name] Carries
+*(Same structure as 3.1 for branch 2.)*
+
+### 3.3 Branch 3 (position 5): What [name] Carries
+*(Same structure for branch 3.)*
+
+### 3.4 The Branches as a Trio — Where They Form a Triad-Within-the-Penta
+*(The three branches alone compose a sub-triad. Read it briefly: where do branches 1-2-3 carry shared resonance that the parents don't? Where does the sibling-field have its own architecture that's distinct from the family-field?)*
+
+End Pass γ. Pass δ closes with the joint operative + shadow.
+
+## pass-delta-template
+
+You are running Pass δ — the **joint operative + shadow** pass — of the family-penta synthesis for {{subject_names}}.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+This pass synthesizes: what is the family-field structurally configured to do COLLECTIVELY, and what shadow does it INHERIT and PROPAGATE? Be specific. The Family-Penta's operational signature is the chart-evidence of joint dharma.
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part IV — Joint Operative + Shadow
+
+### 4.1 The Family-Field's Joint Atmakaraka
+*(Across all five subjects, which graha appears most often as Atmakaraka or strong-aspecting Atmakaraka? That graha carries the FAMILY-FIELD's joint soul-significator. The family is structurally configured around that graha's archetypal current.)*
+
+### 4.2 The Five-Way Pancha Bhuta Coverage Table
+*(Table: Element | Subj-1 | Subj-2 | Subj-3 | Subj-4 | Subj-5 | Penta-total.*
+
+*Then narrate: which elements is the family-field over-loaded with (somatic pressure points)? Which elements is it missing (the family must source these externally to function)? Where does the family have natural coverage that no smaller configuration has?)*
+
+### 4.3 The Joint Tarot Stack
+*(For each subject, their dominant Major Arcanum (derived from Atmakaraka, Lagna, or Sun). Then the joint stack — what archetypal current does the family carry through the cultural-archetypal (Mitwelt) layer? "The Empress × The Hierophant × The Hermit × The Fool × The Star operating together makes ____.")*
+
+### 4.4 The Shared Codon Ring (Gene Keys)
+*(Across the five subjects' Gene Keys spheres, what codon ring (if any) does the family activate? Where the family carries 4 of 6 sides of a codon ring, the field has near-complete genetic-archetypal coverage. Where it has 2-3 sides, the field has a specific incomplete current. Name what the family is structurally configured to TRANSMIT genetically-archetypally.)*
+
+### 4.5 What the Family Is Structurally Configured to Do Collectively
+*(Synthesis: across the next 16-20 years of dasha cycles for all five, what artifact is the family-field structurally configured to PRODUCE in the world? The artifact may be relational (a household, a community node), creative (work that emerges from the field), or transmissive (carrying lineage current forward to the next generation). Name it specifically.)*
+
+### 4.6 The Family Shadow
+*(Honest naming: what shadow does the family-field carry that 3+ members share? Common patterns: a structural Pitru-karaka affliction propagating; a Moon-condition pattern that recurs; a 6th-house adversary cross-mapped across multiple members.*
+
+*The shadow is part of the field's truth, not its disqualification. Naming it is the precondition for transmuting it. Be specific about the chart-architectural source.)*
+
+End Pass δ. Pass ε closes with generational anti-dependency.
+
+## pass-epsilon-template
+
+You are running Pass ε — the **generational anti-dependency** closing pass — of the family-penta synthesis for {{subject_names}}.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+This pass carries the framework's design principle: success = decreasing reliance on the interpreter. Anti-dependency for a family-field means each member becoming structurally UNABLE TO NEED what the others provide — the family matures by structurally completing its own dispersal. Each member becomes a complete instrument that is also part of the field.
+
+NO family-coaching prescriptions. NO compatibility-product framing. **Per-Kosha-layer self-decoding capacity milestones for each member, anatomically grounded.**
+
+## PRIOR PASS OUTPUT
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS PASS — EXACT STRUCTURE
+
+## Part V — Generational Anti-Dependency
+
+### 5.1 The 12-20 Year Arc of the Family-Field
+*(Across the next 12-20 years, the family-field will reconfigure as each member's Mahadasha cycles advance. Plot the major transitions across all five subjects. Where the field will reorganize structurally vs where it remains stable.)*
+
+### 5.2 What Each Member Becomes Unable to Need
+*(For each of the 5 subjects, per Kosha layer, what does that member become structurally unable to need from the family across their new dasha cycle?*
+
+*— **Root-1**: across their new MD, becomes unable to need [X from root-2 / Y from branches].*
+*— **Root-2**: similarly.*
+*— **Branch-1**: across their new MD, becomes unable to need [parents to mediate Z].*
+*— **Branch-2**, **Branch-3**: similarly.*
+
+*Anatomically grounded — where in the body, where in the breath, where in the pattern-engine.)*
+
+### 5.3 The Dispersal as Maturation
+*(Frame the dispersal: when branches become unable to need the roots, the roots are not abandoned — they are RELEASED. When roots become unable to need the branches as ongoing-dependents, the branches are not orphaned — they are EMPOWERED. The family-field structurally completes itself by allowing each member to become a complete instrument.)*
+
+### 5.4 The Joint AKSHARA Artifact
+*(What the family-field, across 16-20 years, writes into the world. The imperishable seed (Anandamaya / Cl(7)) of the joint operative. Its mature form. The thing that outlasts the family's current configuration.)*
+
+### 5.5 The Single Sentence
+*(The family in one sentence — a structural identity claim the reading has earned across 5 passes.)*
+
+### 5.6 The One Practice
+*(The single practice that, if held faithfully across the family, lets each member become unable to need the reading — and lets the family-field become a coherent instrument that doesn't require the interpreter's mediation.)*
+
+End Pass ε. The full 5-pass family-penta reading is now complete.
+
+## overlay-rules
+
+For family-penta mode:
+- **Vimshottari (weight 2.0):** the highest-foregrounded — the family-field's operational calendar IS the 5-way dasha overlap matrix.
+- **Panchanga (weight 1.5):** secondary foreground — the day-of-pivot panchanga across multiple members carries lineage-current.
+- **Tarot (weight 1.5):** the joint Major Arcana stack names the family's archetypal-current.
+- **Gene Keys (weight 1.5):** the codon ring + spheres-of-purpose overlay — the literal genetic-archetypal transmission signature.
+- **Human Design (weight 1.0):** baseline — used in the joint center-definition analysis but not foregrounded.
+- **Nadabrahman (weight 1.0):** baseline — sound/syllabic resonance can carry lineage-current.
+- **I-Ching (weight 0.5):** background.
+- **Biorhythm / Face-Reading / Sigil-Forge (< 1.0):** background unless specifically signaling lineage.
+
+**House overlay:**
+- **4 (root, mother, ancestral home):** primary lineage anchor.
+- **9 (dharma, father, ancestral wisdom):** secondary lineage anchor.
+- **12 (the imperishable, lineage karma):** what comes through from before.
+- **5 (creative offspring, children, generation forward):** what the field generates.
+- **2 (family resources):** the substrate.
+- **3 (siblings, cohort):** the branches-as-siblings architecture.
+
+## glossary
+
+- **Lineage-house axis** — the 4/9/12 house cross-overlay that carries the family's karma. Where 4 (root) and 9 (dharma) meet, the family's structural lineage-current lives.
+- **Root-pair** — the two anchoring members of the family-field (positions 1+2). The branches inherit, contribute, and depart from this anchor.
+- **Pitru karaka** — the soul-significator of the paternal/ancestral lineage. In Jaimini, the 4th-from-Atmakaraka karaka graha.
+- **Generational nakshatra pattern** — when 2+ family members share a nakshatra or its pada-pair, the family carries a generational nakshatra signature.
+- **The dispersal IS the maturation** — anti-dependency for a family-field means each member becoming a complete instrument. The field matures by structurally completing its own dispersal, not by perpetuating dependence.
+- **Codon ring of the family** — when the family's Gene Keys spheres activate consecutive codons in a ring, the family carries a coherent genetic-archetypal transmission current.
+
+## interactions
+
+For the interactive HTML output:
+- **Click a member vertex** in the pentagon SVG → that member's contribution-to-field section (`<section data-member="N">`) auto-scrolls into view; the vertex gets a stroke-width emphasis; the lineage-house glyph ring (IV · IX · XII) faintly glows for 2.5 seconds.
+- **Hover the root-pair shared inner-arc** → tooltip displays the root-field summary (uses `document.body.dataset.bridgeMandate` for the rotating text).
+- **Toggle a vertex's spotlight** by clicking it again — restores all vertices to baseline emphasis.
+
+## lessons
+
+*(No autoresearch passes yet. First Pass 6 entry (#57) will land here per the autoresearch contract — variant axis: Pass α lineage-current strength (4th vs 9th vs 12th house emphasis combinations); mode-specific judge axis: "lineage-current legibility".)*

--- a/scripts/integratedreading/render/interactions/family-penta.ts
+++ b/scripts/integratedreading/render/interactions/family-penta.ts
@@ -1,0 +1,180 @@
+// ─── Family-Penta mode interactions ────────────────────────────────────
+// Layers on top of pentagon topology interactions. Affordances:
+//   - Click a member vertex → that member's contribution-to-field
+//     section auto-scrolls into view + lineage-houses (4/9/12 glyph ring)
+//     faintly glow
+//   - Hover the root-pair shared inner-arc → root-field summary tooltip
+//
+// Per design doc § 5 — Family-Penta affordances row.
+// P4.3 deliverable. Closes #51.
+
+import type { InteractionModule } from './index.js';
+
+export const familyPentaModule: InteractionModule = {
+  scrollTimelineCss: `
+/* ════ Family-Penta mode interactions ═════════════════════════════════ */
+
+/* Each vertex arc carries data-vertex + data-role. Clickable + hoverable. */
+.canvas.interactive[data-mode="family-penta"] .viz svg circle[data-vertex] {
+  cursor: pointer;
+  transition: stroke-width 0.3s ease, filter 0.3s ease;
+}
+.canvas.interactive[data-mode="family-penta"] .viz svg circle[data-vertex]:hover {
+  stroke-width: 2.4 !important;
+  filter: drop-shadow(0 0 10px currentColor);
+}
+.canvas.interactive[data-mode="family-penta"] .viz svg circle[data-vertex][data-spotlighted="true"] {
+  stroke-width: 3 !important;
+  filter: drop-shadow(0 0 14px currentColor);
+}
+
+/* When a vertex is spotlighted, dim the others to background */
+.canvas.interactive[data-mode="family-penta"][data-spotlight] .viz svg circle[data-vertex]:not([data-spotlighted="true"]),
+.canvas.interactive[data-mode="family-penta"][data-spotlight] .viz svg line[data-pair]:not([data-pair*=":spotlight:"]) {
+  opacity: 0.25;
+  transition: opacity 0.3s ease;
+}
+
+/* Lineage-house glyph ring (IV · IX · XII) — gentle pulse on vertex click */
+.canvas.interactive[data-mode="family-penta"][data-lineage-glow] .viz svg g[opacity="0.32"] text {
+  animation: lineage-glow 2.4s ease-in-out;
+}
+@keyframes lineage-glow {
+  0%, 100% { fill-opacity: 0.32; filter: none; }
+  40%      { fill-opacity: 1; filter: drop-shadow(0 0 8px var(--sacred-gold)); }
+}
+
+/* Root-pair shared inner-arc — explicit hover affordance */
+.canvas.interactive[data-mode="family-penta"] .viz svg path[data-root-pair] {
+  cursor: help;
+  transition: stroke-width 0.3s ease, opacity 0.3s ease;
+}
+.canvas.interactive[data-mode="family-penta"] .viz svg path[data-root-pair]:hover {
+  stroke-width: 2 !important;
+  opacity: 0.9 !important;
+}
+
+/* Per-member section anchor (set by orchestrator: data-member="0..4") */
+.canvas.interactive[data-mode="family-penta"] section[data-member] {
+  transition: background 0.5s ease, border-left-color 0.5s ease;
+  border-left: 3px solid transparent;
+  padding-left: 16px;
+  margin-left: -19px;
+}
+.canvas.interactive[data-mode="family-penta"] section[data-member][data-spotlighted="true"] {
+  background: rgba(197,160,23,0.05);
+  border-left-color: var(--sacred-gold);
+}
+`,
+
+  gsapTimeline: `
+// Family-Penta — pentagon vertices fade in sequentially: roots first, then branches
+if (typeof gsap !== 'undefined' && typeof ScrollTrigger !== 'undefined') {
+  document.querySelectorAll('.canvas.interactive[data-mode="family-penta"] .viz svg').forEach(function(svg) {
+    var vertices = svg.querySelectorAll('circle[data-vertex]');
+    var rootArc = svg.querySelector('path[data-root-pair]');
+    if (vertices.length === 0) return;
+
+    var tl = gsap.timeline({
+      scrollTrigger: {
+        trigger: svg,
+        start: 'top 75%',
+        toggleActions: 'play none none reverse',
+      },
+    });
+
+    // Roots first (vertices 0+1)
+    var roots = svg.querySelectorAll('circle[data-vertex][data-role="root"]');
+    if (roots.length > 0) {
+      tl.from(roots, {
+        scale: 0, opacity: 0,
+        duration: 0.7, stagger: 0.12, ease: 'back.out(2)',
+        transformOrigin: 'center', transformBox: 'fill-box',
+      });
+    }
+
+    // Root-pair shared inner-arc draws in next
+    if (rootArc) {
+      tl.from(rootArc, {
+        opacity: 0,
+        duration: 0.5, ease: 'power2.out',
+      }, '-=0.2');
+    }
+
+    // Branches fan out (vertices 2,3,4)
+    var branches = svg.querySelectorAll('circle[data-vertex][data-role="branch"]');
+    if (branches.length > 0) {
+      tl.from(branches, {
+        scale: 0, opacity: 0,
+        duration: 0.6, stagger: 0.12, ease: 'back.out(1.8)',
+        transformOrigin: 'center', transformBox: 'fill-box',
+      }, '-=0.3');
+    }
+
+    // Pair threads sequence in last
+    var threads = svg.querySelectorAll('line[data-pair]');
+    if (threads.length > 0) {
+      tl.from(threads, {
+        opacity: 0,
+        duration: 0.4, stagger: 0.04, ease: 'power2.out',
+      }, '-=0.4');
+    }
+  });
+}
+`,
+
+  eventHandlers: `
+// Family-Penta — click-to-spotlight a member + hover root-pair tooltip
+(function() {
+  var canvas = document.querySelector('.canvas.interactive[data-mode="family-penta"]');
+  if (!canvas) return;
+
+  // ── Click a vertex circle to spotlight the matching member section ──
+  canvas.querySelectorAll('.viz svg circle[data-vertex]').forEach(function(vertex) {
+    vertex.addEventListener('click', function() {
+      var idx = vertex.getAttribute('data-vertex');
+      var currentlySpotlit = vertex.getAttribute('data-spotlighted') === 'true';
+
+      // Clear all spotlights first
+      canvas.querySelectorAll('[data-spotlighted="true"]').forEach(function(el) {
+        el.removeAttribute('data-spotlighted');
+      });
+
+      if (currentlySpotlit) {
+        // Toggle off
+        canvas.removeAttribute('data-spotlight');
+        canvas.removeAttribute('data-lineage-glow');
+        return;
+      }
+
+      // Spotlight this vertex + its corresponding section
+      vertex.setAttribute('data-spotlighted', 'true');
+      canvas.setAttribute('data-spotlight', idx || '');
+
+      // Trigger lineage-house glow animation (one-shot)
+      canvas.setAttribute('data-lineage-glow', 'true');
+      setTimeout(function() { canvas.removeAttribute('data-lineage-glow'); }, 2500);
+
+      var section = canvas.querySelector('section[data-member="' + idx + '"]');
+      if (section) {
+        section.setAttribute('data-spotlighted', 'true');
+        section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+    });
+  });
+
+  // ── Hover root-pair shared inner-arc to show root-field tooltip ─────
+  var rootArc = canvas.querySelector('.viz svg path[data-root-pair]');
+  if (rootArc && typeof window.showBridgeTooltip === 'function') {
+    var mandate = document.body.dataset.bridgeMandate ||
+      'The root-pair anchors the family field. Branches inherit, contribute, and depart from this anchor.';
+    rootArc.addEventListener('mouseenter', function(e) {
+      window.showBridgeTooltip(e, 'ROOT FIELD · ' + mandate);
+    });
+    rootArc.addEventListener('mouseleave', function() {
+      if (window.hideBridgeTooltip) window.hideBridgeTooltip();
+    });
+  }
+})();
+`,
+};

--- a/scripts/integratedreading/render/interactions/index.ts
+++ b/scripts/integratedreading/render/interactions/index.ts
@@ -223,10 +223,12 @@ export const INTERACTION_MODULES: Record<TopologyKey, InteractionModule> = {
 
 import { partnerSynastryModule } from './partner-synastry.js';
 import { businessPartnersModule } from './business-partners.js';
+import { familyPentaModule } from './family-penta.js';
 
 export const MODE_INTERACTION_MODULES: Record<string, InteractionModule> = {
   'partner-synastry': partnerSynastryModule,
   'business-partners': businessPartnersModule,
+  'family-penta': familyPentaModule,
 };
 
 // ────────────────────────────────────────────────────────────────────────

--- a/scripts/integratedreading/render/svg/composite-penta.ts
+++ b/scripts/integratedreading/render/svg/composite-penta.ts
@@ -1,0 +1,280 @@
+// ─── SVG: Composite Pentagon — 5-Subject Family Field ─────────────────
+// Five vertices at 72° intervals on a circle (regular pentagon). Each
+// vertex carries a subject mini-arc. Ten pair-threads (C(5,2)=10) —
+// dominant pairs solid + others faint. Root-pair (vertices 1+2) gets
+// a shared inner-arc distinguishing them from the three branches.
+// Center seed labeled `LINEAGE FIELD` with 5 petals. Lineage-house glyph
+// ring (4/9/12) faint behind the center seed.
+//
+// Per design doc § 5 — `pentagon` topology renderer.
+// P4.2 deliverable. Closes #50.
+
+import { BRAND } from '../styles.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// Types
+// ────────────────────────────────────────────────────────────────────────
+
+export interface PentaSubject {
+  name: string;
+  /** Hex string used for the vertex arc + halo. Conventionally:
+   *  root-1 + root-2 = warm tones (parchment + sacred-gold),
+   *  branches = cool tones (emerald / indigo / witness-violet). */
+  arc_color: string;
+  current_mahadasha_lord?: string;
+  next_mahadasha_lord?: string;
+  next_mahadasha_iso?: string;
+  /** Optional — display role label below the subject name */
+  role?: 'root' | 'branch';
+}
+
+export interface CompositePentaData {
+  /** Exactly 5 subjects. Convention: indices 0+1 = roots (root-pair gets
+   *  shared inner-arc); indices 2,3,4 = branches. */
+  subjects: [PentaSubject, PentaSubject, PentaSubject, PentaSubject, PentaSubject];
+  /** Optional explicit pair-thread emphasis. Each pair = [i,j] where
+   *  i<j ∈ {0..4}. Pairs in this list render solid; pairs absent render faint.
+   *  If omitted, the root-pair (0,1) is the only dominant pair by default. */
+  dominant_pairs?: Array<[number, number]>;
+  /** Optional themes that recur across all 5 charts — bedrock currents. */
+  shared_keys?: string[];
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Geometry helpers
+// ────────────────────────────────────────────────────────────────────────
+
+function formatPivot(iso?: string): string {
+  if (!iso) return '';
+  const m = iso.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!m) return iso.slice(0, 10);
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  return `${parseInt(m[3], 10)} ${months[parseInt(m[2], 10) - 1]} ${m[1]}`;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Renderer
+// ────────────────────────────────────────────────────────────────────────
+
+export function renderCompositePenta(
+  data: CompositePentaData,
+  opts: { width?: number } = {},
+): string {
+  const W = opts.width ?? 720;
+  const H = W;
+  const cx = W / 2, cy = H / 2 + 14;
+  const fieldR = W * 0.34;
+  const arcRadius = W * 0.085;
+  const labelR = fieldR + arcRadius + 30;
+
+  // 5 vertices at 72° intervals, root-pair (0,1) at the TOP (offset to
+  // 90° and 162° respectively for the visual "parents-above" convention).
+  // Pentagon angle sequence (counter-clockwise from top-right):
+  //   -90° (top)   →   roots/branches mix; here we use:
+  //   i=0 → -126° (upper-left)   = root-1
+  //   i=1 →  -54° (upper-right)  = root-2
+  //   i=2 →   18° (right)        = branch-1
+  //   i=3 →   90° (bottom)       = branch-2
+  //   i=4 →  162° (left)         = branch-3
+  // This puts the root-pair as a horizontal couplet at the top, with the
+  // three branches fanning out below — the family-tree convention.
+  const vertexAngles = [-126, -54, 18, 90, 162].map((d) => (d * Math.PI) / 180);
+  const positions = vertexAngles.map((a) => ({
+    x: cx + fieldR * Math.cos(a),
+    y: cy + fieldR * Math.sin(a),
+    angle: a,
+  }));
+
+  // ── Subject arcs (halo + main + inner mist + center dot) ────────────
+  const arcs = data.subjects.map((s, i) => {
+    const p = positions[i];
+    return `
+      <!-- subject ${i}: halo + arc + mist + dot -->
+      <circle cx="${p.x}" cy="${p.y}" r="${arcRadius + 12}"
+              fill="none" stroke="${s.arc_color}" stroke-width="0.4" opacity="0.18"/>
+      <circle cx="${p.x}" cy="${p.y}" r="${arcRadius + 5}"
+              fill="none" stroke="${s.arc_color}" stroke-width="0.6" opacity="0.32"/>
+      <circle cx="${p.x}" cy="${p.y}" r="${arcRadius}"
+              fill="none" stroke="${s.arc_color}" stroke-width="1.4" opacity="0.85"
+              data-vertex="${i}" data-role="${s.role ?? (i < 2 ? 'root' : 'branch')}"/>
+      <circle cx="${p.x}" cy="${p.y}" r="${arcRadius - 5}"
+              fill="${s.arc_color}" fill-opacity="0.06" stroke="none"/>
+      <circle cx="${p.x}" cy="${p.y}" r="2.2"
+              fill="${s.arc_color}" opacity="0.8"/>`;
+  }).join('');
+
+  // ── Subject labels — on radial sight-lines from center ──────────────
+  const labels = data.subjects.map((s, i) => {
+    const a = vertexAngles[i];
+    const lx = cx + labelR * Math.cos(a);
+    const ly = cy + labelR * Math.sin(a);
+
+    // Anchor based on quadrant of label
+    let anchor: 'start' | 'middle' | 'end';
+    if (Math.cos(a) > 0.25) anchor = 'start';
+    else if (Math.cos(a) < -0.25) anchor = 'end';
+    else anchor = 'middle';
+
+    // Whether the label is above (top of pentagon) or below center
+    const above = Math.sin(a) < 0;
+
+    const mdLine = s.current_mahadasha_lord && s.next_mahadasha_lord
+      ? `${s.current_mahadasha_lord.toUpperCase()} → ${s.next_mahadasha_lord.toUpperCase()}`
+      : '';
+    const pivot = formatPivot(s.next_mahadasha_iso);
+    const roleTag = (s.role ?? (i < 2 ? 'root' : 'branch')).toUpperCase();
+
+    // Stack offsets vary by quadrant — labels above-vertex stack upward,
+    // labels below-vertex stack downward.
+    const nameDy = above ? -14 : 4;
+    const roleDy = above ? -28 : -8;
+    const mdDy   = above ? 0   : 18;
+    const pivDy  = above ? 14  : 32;
+
+    return `
+      <!-- label for subject ${i} (${roleTag.toLowerCase()}) -->
+      <text x="${lx}" y="${ly + roleDy}" text-anchor="${anchor}"
+            font-family="SF Mono, monospace" font-size="6.5"
+            fill="${BRAND.coherenceEmerald}" letter-spacing="0.32em" opacity="0.7">${roleTag}</text>
+      <text x="${lx}" y="${ly + nameDy}" text-anchor="${anchor}"
+            font-family="Panchang, serif" font-weight="700" font-size="13"
+            fill="${s.arc_color}" letter-spacing="0.05em">${s.name.toUpperCase()}</text>
+      ${mdLine ? `<text x="${lx}" y="${ly + mdDy}" text-anchor="${anchor}"
+            font-family="SF Mono, monospace" font-size="7" font-weight="600"
+            fill="${BRAND.mutedSilver}" letter-spacing="0.16em">${mdLine}</text>` : ''}
+      ${pivot ? `<text x="${lx}" y="${ly + pivDy}" text-anchor="${anchor}"
+            font-family="Panchang, serif" font-style="italic" font-size="8.5"
+            fill="${BRAND.sacredGold}" letter-spacing="0.02em">pivot · ${pivot}</text>` : ''}`;
+  }).join('');
+
+  // ── Pair-threads: all C(5,2)=10 pairs; dominant solid, others faint ─
+  const allPairs: Array<[number, number]> = [];
+  for (let i = 0; i < 5; i++) {
+    for (let j = i + 1; j < 5; j++) {
+      allPairs.push([i, j]);
+    }
+  }
+  const dominantSet = new Set(
+    (data.dominant_pairs ?? [[0, 1]]).map(([a, b]) => `${Math.min(a, b)}-${Math.max(a, b)}`),
+  );
+  const threadStrokes = allPairs.map(([i, j], idx) => {
+    const a = positions[i], b = positions[j];
+    const dx = b.x - a.x, dy = b.y - a.y;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    const ux = dx / len, uy = dy / len;
+    const ax = a.x + ux * arcRadius;
+    const ay = a.y + uy * arcRadius;
+    const bx = b.x - ux * arcRadius;
+    const by = b.y - uy * arcRadius;
+    const dominant = dominantSet.has(`${i}-${j}`);
+    if (dominant) {
+      const ca = data.subjects[i].arc_color;
+      const cb = data.subjects[j].arc_color;
+      const gradId = `penta-thread-${idx}`;
+      return `
+        <defs>
+          <linearGradient id="${gradId}" x1="${ax}" y1="${ay}" x2="${bx}" y2="${by}" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" stop-color="${ca}" stop-opacity="0.6"/>
+            <stop offset="50%" stop-color="${BRAND.sacredGold}" stop-opacity="0.7"/>
+            <stop offset="100%" stop-color="${cb}" stop-opacity="0.6"/>
+          </linearGradient>
+        </defs>
+        <line x1="${ax}" y1="${ay}" x2="${bx}" y2="${by}"
+              stroke="${BRAND.sacredGold}" stroke-width="3" stroke-opacity="0.08"/>
+        <line x1="${ax}" y1="${ay}" x2="${bx}" y2="${by}"
+              stroke="url(#${gradId})" stroke-width="1.1"
+              data-pair="${i}-${j}" data-dominant="true"/>`;
+    } else {
+      return `
+        <line x1="${ax}" y1="${ay}" x2="${bx}" y2="${by}"
+              stroke="${BRAND.sacredGold}" stroke-width="0.5" stroke-opacity="0.16"
+              data-pair="${i}-${j}" data-dominant="false"/>`;
+    }
+  }).join('');
+
+  // ── Root-pair shared inner-arc — the distinguishing root-field mark ──
+  const root1 = positions[0], root2 = positions[1];
+  const rootMidX = (root1.x + root2.x) / 2;
+  const rootMidY = (root1.y + root2.y) / 2;
+  // Arc connecting the two roots, bowing UPWARD (toward top of pentagon)
+  const rootInnerArc = `
+    <!-- Root-pair shared inner-arc — bowing upward, distinguishes roots from branches -->
+    <path d="M ${root1.x + arcRadius * 0.3} ${root1.y}
+             Q ${rootMidX} ${rootMidY - arcRadius * 2}
+             ${root2.x - arcRadius * 0.3} ${root2.y}"
+          fill="none" stroke="${BRAND.sacredGold}" stroke-width="1.2" opacity="0.55"
+          stroke-dasharray="0" data-root-pair="true"/>
+    <text x="${rootMidX}" y="${rootMidY - arcRadius * 2.2}" text-anchor="middle"
+          font-family="SF Mono, monospace" font-size="7" font-weight="600"
+          fill="${BRAND.sacredGold}" letter-spacing="0.28em"
+          style="paint-order: stroke; stroke: ${BRAND.voidBlack}; stroke-width: 3px; stroke-linejoin: round;">ROOT FIELD</text>`;
+
+  // ── Center seed: 5 petals + LINEAGE FIELD label + lineage-house ring ─
+  const petals = vertexAngles.map((a) => {
+    const px = cx + 28 * Math.cos(a);
+    const py = cy + 28 * Math.sin(a);
+    return `<line x1="${cx}" y1="${cy}" x2="${px}" y2="${py}"
+                  stroke="${BRAND.sacredGold}" stroke-width="0.4" opacity="0.55"/>`;
+  }).join('');
+
+  // Lineage-house glyphs (4 / 9 / 12) faint behind the center seed
+  const houseRing = `
+    <!-- Lineage-house glyph ring (4 / 9 / 12) — faint behind center -->
+    <g opacity="0.32">
+      <text x="${cx}" y="${cy + 38}" text-anchor="middle"
+            font-family="Panchang, serif" font-size="7" font-style="italic"
+            fill="${BRAND.mutedSilver}" letter-spacing="0.4em">IV · IX · XII</text>
+    </g>`;
+
+  const center = `
+    <circle cx="${cx}" cy="${cy}" r="48"
+            fill="${BRAND.voidBlack}" stroke="${BRAND.sacredGold}" stroke-width="1.2"/>
+    <circle cx="${cx}" cy="${cy}" r="36"
+            fill="none" stroke="${BRAND.sacredGold}" stroke-width="0.4" opacity="0.4"/>
+    <circle cx="${cx}" cy="${cy}" r="24"
+            fill="none" stroke="${BRAND.sacredGold}" stroke-width="0.3" opacity="0.3"/>
+    ${petals}
+    ${houseRing}
+    <text x="${cx}" y="${cy - 4}" text-anchor="middle"
+          font-family="Panchang, serif" font-size="11" font-weight="700"
+          fill="${BRAND.sacredGold}" letter-spacing="0.22em">LINEAGE</text>
+    <text x="${cx}" y="${cy + 10}" text-anchor="middle"
+          font-family="SF Mono, monospace" font-size="6.5"
+          fill="${BRAND.mutedSilver}" letter-spacing="0.32em">FIELD</text>`;
+
+  // ── Shared-keys legend (bedrock currents) at bottom ─────────────────
+  const sharedLegend = data.shared_keys && data.shared_keys.length > 0 ? `
+    <text x="${cx}" y="${H - 38}" text-anchor="middle"
+          font-family="SF Mono, monospace" font-size="7.5"
+          fill="${BRAND.mutedSilver}" letter-spacing="0.32em">SHARED LINEAGE CURRENTS</text>
+    <text x="${cx}" y="${H - 18}" text-anchor="middle"
+          font-family="Panchang, serif" font-size="11" font-style="italic" font-weight="500"
+          fill="${BRAND.sacredGold}" letter-spacing="0.01em">${data.shared_keys.join('   ·   ')}</text>` : '';
+
+  return `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}" width="100%" preserveAspectRatio="xMidYMid meet">
+  <defs>
+    <radialGradient id="penta-bg" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="${BRAND.sacredGold}" stop-opacity="0.06"/>
+      <stop offset="60%" stop-color="${BRAND.witnessViolet}" stop-opacity="0.04"/>
+      <stop offset="100%" stop-color="${BRAND.voidBlack}" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="${W}" height="${H}" fill="url(#penta-bg)"/>
+  ${threadStrokes}
+  ${rootInnerArc}
+  ${arcs}
+  ${labels}
+  ${center}
+  ${sharedLegend}
+</svg>`;
+}
+
+export function planetColor(name: string): string {
+  const map: Record<string, string> = {
+    sun: BRAND.sacredGold, moon: BRAND.parchment, mars: BRAND.terracotta,
+    mercury: BRAND.coherenceEmerald, jupiter: '#E8B923', venus: '#D4A8FF',
+    saturn: '#5A7090', rahu: BRAND.witnessViolet, ketu: BRAND.mutedSilver,
+  };
+  return map[name.toLowerCase()] || BRAND.flowIndigo;
+}

--- a/scripts/integratedreading/render/svg/index.ts
+++ b/scripts/integratedreading/render/svg/index.ts
@@ -12,6 +12,7 @@
 import type { TopologyKey } from '../../modes/parser.js';
 import { renderCompositeResonance, type CompositeResonanceData } from './composite-resonance.js';
 import { renderCompositeTriad, type CompositeTriadData } from './composite-triad.js';
+import { renderCompositePenta, type CompositePentaData } from './composite-penta.js';
 
 // ────────────────────────────────────────────────────────────────────────
 // Renderer function shape
@@ -44,10 +45,6 @@ class NotImplementedError extends Error {
   }
 }
 
-function pentagonStub(_data: any, _opts?: RendererOpts): string {
-  throw new NotImplementedError('pentagon', 'issue #50 (P4.2)');
-}
-
 function webGraphStub(_data: any, _opts?: RendererOpts): string {
   throw new NotImplementedError('web-graph', 'issue #53 (P5.2)');
 }
@@ -59,7 +56,7 @@ function webGraphStub(_data: any, _opts?: RendererOpts): string {
 export const TOPOLOGY_RENDERERS: Record<TopologyKey, RendererFn<any>> = {
   'dyad-arc': renderCompositeResonance as RendererFn<CompositeResonanceData>,
   'triad-triangle': renderCompositeTriad as RendererFn<CompositeTriadData>,
-  'pentagon': pentagonStub,
+  'pentagon': renderCompositePenta as RendererFn<CompositePentaData>,
   'web-graph': webGraphStub,
 };
 
@@ -101,3 +98,4 @@ export function renderByTopology(
 export type { TopologyKey } from '../../modes/parser.js';
 export { renderCompositeResonance, type CompositeResonanceData } from './composite-resonance.js';
 export { renderCompositeTriad, type CompositeTriadData, type TriadSubject } from './composite-triad.js';
+export { renderCompositePenta, type CompositePentaData, type PentaSubject } from './composite-penta.js';

--- a/tests/family-penta.test.ts
+++ b/tests/family-penta.test.ts
@@ -1,0 +1,268 @@
+// ─── P4 — Family-Penta tests ───────────────────────────────────────────
+// Covers #49 (family-penta.md), #50 (composite-penta.ts), #51 (interaction).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+import { parseModeDoc } from '../scripts/integratedreading/modes/parser.js';
+import {
+  TOPOLOGY_RENDERERS,
+  renderByTopology,
+  renderCompositePenta,
+} from '../scripts/integratedreading/render/svg/index.js';
+import {
+  MODE_INTERACTION_MODULES,
+  buildInteractionPayload,
+} from '../scripts/integratedreading/render/interactions/index.js';
+import { renderInteractiveHTMLPage, type PartBlock } from '../scripts/integratedreading/render/templates.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// Mode doc parses (P4.1 #49)
+// ────────────────────────────────────────────────────────────────────────
+
+describe('family-penta mode doc (P4.1)', () => {
+  const path = resolve('scripts/integratedreading/modes/family-penta.md');
+
+  it('parses without errors', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.mode, 'family-penta');
+  });
+
+  it('requires exactly 5 subjects', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.subject_count.min, 5);
+    assert.equal(doc.frontmatter.subject_count.max, 5);
+  });
+
+  it('declares 5 passes (α β γ δ ε)', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.pass_plan.length, 5);
+    assert.deepEqual(doc.frontmatter.pass_plan.map((p) => p.id), ['alpha', 'beta', 'gamma', 'delta', 'epsilon']);
+  });
+
+  it('targets 13-15k words total', () => {
+    const doc = parseModeDoc(path);
+    const sum = doc.frontmatter.pass_plan.reduce((s, p) => s + p.target_words, 0);
+    assert.ok(sum >= 13000, `total = ${sum}, expected >= 13000`);
+    assert.ok(sum <= 15000, `total = ${sum}, expected <= 15000`);
+  });
+
+  it('foregrounds vimshottari at weight 2.0', () => {
+    const doc = parseModeDoc(path);
+    assert.ok(doc.frontmatter.engine_overlay_weights.vimshottari >= 2.0);
+  });
+
+  it('declares house_overlay includes 4, 9, 12 (lineage axis)', () => {
+    const doc = parseModeDoc(path);
+    assert.ok(doc.frontmatter.house_overlay.includes(4));
+    assert.ok(doc.frontmatter.house_overlay.includes(9));
+    assert.ok(doc.frontmatter.house_overlay.includes(12));
+  });
+
+  it('declares svg_topology: pentagon', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.svg_topology, 'pentagon');
+  });
+
+  it('roles list has 5 entries with root + branch convention', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.roles.length, 5);
+    assert.ok(doc.frontmatter.roles[0].includes('root'));
+    assert.ok(doc.frontmatter.roles[1].includes('root'));
+    assert.ok(doc.frontmatter.roles[4].includes('branch'));
+  });
+
+  it('every pass template resolves to a body section', () => {
+    const doc = parseModeDoc(path);
+    for (const pass of doc.frontmatter.pass_plan) {
+      assert.ok(doc.sections[pass.template], `missing section: ${pass.template}`);
+    }
+  });
+
+  it('bridge mandate names Pitru-karaka + lineage-house + generational-nakshatra + Gene-Key', () => {
+    const doc = parseModeDoc(path);
+    const m = doc.frontmatter.bridge_mandates[0];
+    assert.match(m, /Lineage-house|4\/9\/12/);
+    assert.match(m, /Pitru/);
+    assert.match(m, /[Nn]akshatra/);
+    assert.match(m, /Gene[ -]Key/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Pentagon SVG renderer (P4.2 #50)
+// ────────────────────────────────────────────────────────────────────────
+
+const FIVE_SUBJECTS_DATA = {
+  subjects: [
+    { name: 'Root-1', arc_color: '#F0EDE3', role: 'root' as const, current_mahadasha_lord: 'Jupiter', next_mahadasha_lord: 'Saturn', next_mahadasha_iso: '2027-03-15' },
+    { name: 'Root-2', arc_color: '#C5A017', role: 'root' as const, current_mahadasha_lord: 'Venus', next_mahadasha_lord: 'Sun', next_mahadasha_iso: '2026-11-20' },
+    { name: 'Branch-1', arc_color: '#10B5A7', role: 'branch' as const, current_mahadasha_lord: 'Rahu', next_mahadasha_lord: 'Jupiter', next_mahadasha_iso: '2028-09-14' },
+    { name: 'Branch-2', arc_color: '#0B50FB', role: 'branch' as const, current_mahadasha_lord: 'Mars', next_mahadasha_lord: 'Rahu', next_mahadasha_iso: '2029-05-10' },
+    { name: 'Branch-3', arc_color: '#2D0050', role: 'branch' as const, current_mahadasha_lord: 'Ketu', next_mahadasha_lord: 'Venus', next_mahadasha_iso: '2030-01-08' },
+  ] as [any, any, any, any, any],
+  dominant_pairs: [[0, 1]] as Array<[number, number]>,
+  shared_keys: ['The Hermit · The Empress · Pushya Lineage'],
+};
+
+describe('pentagon SVG renderer (P4.2)', () => {
+  it('is registered in TOPOLOGY_RENDERERS as `pentagon`', () => {
+    assert.ok(TOPOLOGY_RENDERERS.pentagon);
+    assert.equal(typeof TOPOLOGY_RENDERERS.pentagon, 'function');
+  });
+
+  it('emits valid SVG string', () => {
+    const svg = renderCompositePenta(FIVE_SUBJECTS_DATA, { width: 720 });
+    assert.match(svg, /<svg xmlns/);
+    assert.match(svg, /<\/svg>/);
+  });
+
+  it('includes all 5 subject names', () => {
+    const svg = renderCompositePenta(FIVE_SUBJECTS_DATA, { width: 720 });
+    assert.match(svg, /ROOT-1/);
+    assert.match(svg, /ROOT-2/);
+    assert.match(svg, /BRANCH-1/);
+    assert.match(svg, /BRANCH-2/);
+    assert.match(svg, /BRANCH-3/);
+  });
+
+  it('marks each vertex circle with data-vertex + data-role attributes', () => {
+    const svg = renderCompositePenta(FIVE_SUBJECTS_DATA, { width: 720 });
+    for (let i = 0; i < 5; i++) {
+      assert.match(svg, new RegExp(`data-vertex="${i}"`));
+    }
+    assert.match(svg, /data-role="root"/);
+    assert.match(svg, /data-role="branch"/);
+  });
+
+  it('renders all C(5,2)=10 pair-threads with data-pair attribute', () => {
+    const svg = renderCompositePenta(FIVE_SUBJECTS_DATA, { width: 720 });
+    const matches = svg.match(/data-pair="\d-\d"/g) ?? [];
+    assert.equal(matches.length, 10);
+  });
+
+  it('marks root-pair (0-1) as dominant when default dominant_pairs', () => {
+    const svg = renderCompositePenta(FIVE_SUBJECTS_DATA, { width: 720 });
+    // The dominant pair line uses url(#penta-thread-...) gradient stroke
+    assert.match(svg, /data-pair="0-1" data-dominant="true"/);
+    // Non-dominant pairs are marked false
+    assert.match(svg, /data-pair="0-2" data-dominant="false"/);
+  });
+
+  it('renders the root-pair shared inner-arc with data-root-pair attribute', () => {
+    const svg = renderCompositePenta(FIVE_SUBJECTS_DATA, { width: 720 });
+    assert.match(svg, /data-root-pair="true"/);
+    assert.match(svg, /ROOT FIELD/);
+  });
+
+  it('renders LINEAGE FIELD center seed + lineage-house glyph ring', () => {
+    const svg = renderCompositePenta(FIVE_SUBJECTS_DATA, { width: 720 });
+    assert.match(svg, /LINEAGE/);
+    assert.match(svg, /FIELD/);
+    assert.match(svg, /IV · IX · XII/);
+  });
+
+  it('renders shared_keys legend when provided', () => {
+    const svg = renderCompositePenta(FIVE_SUBJECTS_DATA, { width: 720 });
+    assert.match(svg, /SHARED LINEAGE CURRENTS/);
+    assert.match(svg, /Pushya Lineage/);
+  });
+
+  it('omits shared_keys legend when not provided', () => {
+    const dataNoKeys = { ...FIVE_SUBJECTS_DATA, shared_keys: [] };
+    const svg = renderCompositePenta(dataNoKeys, { width: 720 });
+    assert.ok(!svg.includes('SHARED LINEAGE CURRENTS'));
+  });
+
+  it('renderByTopology dispatches pentagon correctly', () => {
+    const svg = renderByTopology('pentagon', FIVE_SUBJECTS_DATA, { width: 720 });
+    assert.match(svg, /<svg xmlns/);
+    assert.match(svg, /LINEAGE/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Family-Penta interaction module (P4.3 #51)
+// ────────────────────────────────────────────────────────────────────────
+
+describe('family-penta interaction module (P4.3)', () => {
+  it('is registered in MODE_INTERACTION_MODULES', () => {
+    assert.ok(MODE_INTERACTION_MODULES['family-penta']);
+  });
+
+  it('CSS targets clickable vertex circles + data-spotlighted state', () => {
+    const m = MODE_INTERACTION_MODULES['family-penta'];
+    assert.match(m.scrollTimelineCss, /data-vertex/);
+    assert.match(m.scrollTimelineCss, /data-spotlighted/);
+  });
+
+  it('CSS targets root-pair shared inner-arc with hover affordance', () => {
+    const m = MODE_INTERACTION_MODULES['family-penta'];
+    assert.match(m.scrollTimelineCss, /data-root-pair/);
+    assert.match(m.scrollTimelineCss, /cursor:\s*help/);
+  });
+
+  it('CSS includes lineage-house glow keyframes', () => {
+    const m = MODE_INTERACTION_MODULES['family-penta'];
+    assert.match(m.scrollTimelineCss, /lineage-glow|@keyframes lineage-glow/);
+  });
+
+  it('GSAP timeline reveals roots before branches', () => {
+    const m = MODE_INTERACTION_MODULES['family-penta'];
+    assert.match(m.gsapTimeline, /data-role="root"/);
+    assert.match(m.gsapTimeline, /data-role="branch"/);
+  });
+
+  it('event handlers implement click-to-spotlight + root-pair tooltip', () => {
+    const m = MODE_INTERACTION_MODULES['family-penta'];
+    assert.match(m.eventHandlers, /data-spotlighted/);
+    assert.match(m.eventHandlers, /section\[data-member="/);
+    assert.match(m.eventHandlers, /data-lineage-glow/);
+    assert.match(m.eventHandlers, /data-root-pair/);
+  });
+
+  it('event handlers reference scrollIntoView for click-to-section', () => {
+    const m = MODE_INTERACTION_MODULES['family-penta'];
+    assert.match(m.eventHandlers, /scrollIntoView/);
+  });
+
+  it('buildInteractionPayload composes family-penta on top of pentagon topology', () => {
+    const payload = buildInteractionPayload('pentagon', 'family-penta');
+    assert.match(payload.css, /Family-Penta mode interactions/);
+    assert.match(payload.handlers, /click-to-spotlight|data-spotlighted/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// renderInteractiveHTMLPage with family-penta mode + pentagon topology
+// ────────────────────────────────────────────────────────────────────────
+
+describe('renderInteractiveHTMLPage — family-penta wiring', () => {
+  const samplePart: PartBlock = {
+    partNum: 1, romanNumeral: 'I', title: 'Lineage Field', contentHtml: '<p>x</p>',
+  };
+
+  it('emits data-mode="family-penta" on .canvas.interactive', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'F1 × F2 × F3 × F4 × F5', birth_date: '2026-01-01' },
+      topology: 'pentagon',
+      mode: 'family-penta',
+      parts: [samplePart],
+    });
+    assert.match(html, /class="canvas interactive" data-mode="family-penta"/);
+  });
+
+  it('inlines family-penta interaction CSS + handlers', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'F1 × F2 × F3 × F4 × F5', birth_date: '2026-01-01' },
+      topology: 'pentagon',
+      mode: 'family-penta',
+      parts: [samplePart],
+    });
+    assert.match(html, /Family-Penta mode interactions/);
+    assert.match(html, /click-to-spotlight|data-spotlighted/);
+  });
+});

--- a/tests/mode-parser.test.ts
+++ b/tests/mode-parser.test.ts
@@ -338,11 +338,16 @@ describe('SVG renderer-dispatcher', () => {
     assert.match(svg, /ALICE/);
   });
 
-  it('pentagon topology throws NotImplementedError pointing to issue #50', () => {
-    assert.throws(
-      () => renderByTopology('pentagon', {}),
-      /not yet implemented.*#50/,
-    );
+  it('pentagon topology renders (P4.2 #50 landed)', () => {
+    // After PR #50, pentagon is a real renderer. Smoke-test it returns SVG.
+    const fakeFive = {
+      subjects: Array.from({ length: 5 }, (_, i) => ({ name: `S${i}`, arc_color: '#10B5A7' })),
+      dominant_pairs: [[0, 1]],
+      shared_keys: [],
+    } as any;
+    const svg = renderByTopology('pentagon', fakeFive, { width: 720 });
+    assert.match(svg, /<svg xmlns/);
+    assert.match(svg, /LINEAGE/);
   });
 
   it('web-graph topology throws NotImplementedError pointing to issue #53', () => {


### PR DESCRIPTION
## Summary
Phase 4 — the **first 5-subject reading mode**. New pentagon SVG topology, 5-pass kinship-field mode doc, mode-specific click-to-spotlight interaction. Each piece registers cleanly through the contract substrate (P0).

## Closes
- Closes #49 — P4.1 family-penta.md (5-pass lineage)
- Closes #50 — P4.2 composite-penta.ts (pentagon SVG)
- Closes #51 — P4.3 Family-Penta interaction module

## What changed

**New SVG topology: pentagon** (\`render/svg/composite-penta.ts\`, 280 LOC)
- 5 vertices at 72° intervals; family-tree visual convention (roots horizontal at top, branches fanning down)
- C(5,2)=10 pair-threads; default dominant pair = root-pair (0-1) drawn as gradient + faint backgrounds for the other 9
- Root-pair shared inner-arc bowing upward + ROOT FIELD label
- LINEAGE FIELD center seed with 5 petals + faint IV·IX·XII lineage-house glyph ring
- Replaces \`pentagonStub\` in TOPOLOGY_RENDERERS

**New mode: family-penta** (\`modes/family-penta.md\`, 5-pass, 13-15k word target)
- Pass α: Lineage Karma Field · β: Roots · γ: Branches · δ: Joint Operative + Shadow · ε: Generational Anti-Dependency
- Engine overlays: vimshottari 2.0, panchanga 1.5, tarot 1.5, gene-keys 1.5
- House overlay [4, 9, 12, 5, 2, 3] — lineage axis primary
- Bridge mandate: Lineage-house × Pitru-karaka × Generational-nakshatra × Gene-Key-sphere-of-purpose

**Mode interaction** (\`render/interactions/family-penta.ts\`)
- Click vertex → \`section[data-member]\` auto-scrolls into view + lineage-house glyph ring glows for 2.5s
- Hover root-pair shared inner-arc → tooltip with root-field summary
- GSAP timeline: roots fade in first → root-arc draws → branches fan in → pair-threads sequence

**Orchestrator** (\`integratedreading-mode.ts\`, +25 LOC)
- \`buildPentaSvgData\` helper: warm tones for roots (0+1), cool tones for branches (2-4)
- SVG dispatch adds pentagon branch

## Verification
- 101/101 tests pass (31 new in this PR + 70 prior)
- Family-penta dry-run on 5-subject fixture passes
- All prior modes still dry-run cleanly

## Test plan
- [ ] \`npm test\` → 101/101 pass
- [ ] Dry-run: \`integratedreading-mode.ts --mode family-penta --subjects-dir <dir-with-5-cfgs> --output-dir <out> --dry-run\`
- [ ] Live run produces 13-15k word reading + pentagon SVG
- [ ] HTML artifact: click any vertex → scrolls to that member's section + lineage glyph glows

🤖 Generated with [Claude Code](https://claude.com/claude-code)