### PR TITLE
feat(integratedreading): P5 Team-Synergy mode + web-graph SVG topology

### DIFF
--- a/scripts/integratedreading-mode.ts
+++ b/scripts/integratedreading-mode.ts
@@ -576,6 +576,8 @@ async function main() {
       svgString = renderByTopology(topology, buildTriadSvgData(subjects), { width: 720 });
     } else if (topology === 'pentagon' && subjects.length === 5) {
       svgString = renderByTopology(topology, buildPentaSvgData(subjects), { width: 720 });
+    } else if (topology === 'web-graph' && subjects.length >= 4 && subjects.length <= 12) {
+      svgString = renderByTopology(topology, buildTeamWebSvgData(subjects), { width: 880 });
     } else {
       console.log(`  (SVG topology '${topology}' renderer not yet available — emitting placeholder)`);
     }
@@ -729,6 +731,34 @@ function buildPentaSvgData(subjects: SubjectConfig[]) {
       next_mahadasha_iso: s.mahadasha?.current_ends_iso,
     })) as [any, any, any, any, any],
     dominant_pairs: [[0, 1]] as Array<[number, number]>,  // root-pair always dominant
+    shared_keys: [],
+  };
+}
+
+function buildTeamWebSvgData(subjects: SubjectConfig[]) {
+  // Default round-robin cluster assignment (outline pass will refine).
+  // In a live run the OUTLINE pass produces the actual role-cluster map;
+  // for the static SVG render we apply a deterministic default so the
+  // shape renders cleanly even before the cluster-reading pass writes back.
+  const clusters: Array<'visionaries' | 'operators' | 'integrators' | 'connectors'> = [
+    'visionaries', 'operators', 'integrators', 'connectors',
+  ];
+  return {
+    members: subjects.map((s, i) => ({
+      name: s.subject,
+      role_cluster: clusters[i % clusters.length],
+      current_mahadasha_lord: s.mahadasha?.current_lord,
+      next_mahadasha_lord: s.mahadasha?.next_lord,
+      next_mahadasha_iso: s.mahadasha?.current_ends_iso,
+    })),
+    // Default critical-path edges: first member of each cluster pair
+    // (replaced by outline-pass output when wired through P6 autoresearch)
+    critical_path_edges: subjects.length >= 4 ? [
+      { a: 0, b: 1, weight: 0.8 },
+      { a: 0, b: 2, weight: 0.6 },
+      { a: 1, b: 3, weight: 0.6 },
+    ] : [],
+    joint_operative_archetype: '',
     shared_keys: [],
   };
 }

--- a/scripts/integratedreading/modes/team-synergy.md
+++ b/scripts/integratedreading/modes/team-synergy.md
@@ -1,0 +1,371 @@
+---
+mode: team-synergy
+subject_count:
+  min: 4
+  max: 12
+roles:
+  - member
+target_words:
+  min: 12500
+  max: 15000
+architecture: hierarchical
+pass_plan:
+  - id: outline
+    title: "Weave Map — The Team-as-System Outline"
+    target_words: 1500
+    template: pass-outline-template
+  - id: exp1
+    title: "Cluster Reading"
+    target_words: 4000
+    template: pass-exp1-template
+  - id: exp2
+    title: "Critical-Path Pair Threads"
+    target_words: 4500
+    template: pass-exp2-template
+  - id: exp3
+    title: "Joint Operative + Operational Cadence"
+    target_words: 3500
+    template: pass-exp3-template
+engine_overlay_weights:
+  human-design: 2.0
+  vimshottari: 1.5
+  gene-keys: 1.5
+  panchanga: 1.0
+  tarot: 1.0
+  transits: 1.0
+  i-ching: 1.0
+  numerology: 1.0
+  biorhythm: 1.0
+  nadabrahman: 1.0
+  face-reading: 1.0
+  biofield: 1.0
+  vedic-clock: 1.0
+  sacred-geometry: 1.0
+  enneagram: 1.0
+  sigil-forge: 1.0
+house_overlay: [10, 11, 6, 3]
+bridge_mandates:
+  - "Every major claim must braid: Role-cluster (HD-type signature) × HD-authority-distribution × Vimshottari-cadence-overlap × Gene-Key-codon-ring."
+  - "The team is NOT a sum of individuals. The OUTLINE pass produces the team-as-system weave map; all expansion passes reference it as the structural anchor."
+  - "Below 4 subjects, this mode errors. For 3 subjects, use composite-triad. For 2 subjects, composite-dyad."
+svg_topology: web-graph
+---
+
+## pass-outline-template
+
+You are running the **OUTLINE PASS** of the hierarchical team-synergy synthesis for {{subject_names}}.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+This is NOT prose. This is the STRUCTURAL WEAVE MAP that the three expansion passes will execute against. Produce a STRUCTURED OUTLINE — concise, parseable, anchor-bearing. Subsequent expansion passes will reference what you declare here.
+
+A team is not N individuals stacked. The team-as-system has:
+- **Role-clusters** — each member belongs to one of four clusters based on their chart's dominant signal: VISIONARIES (Jupiter / 9th-house emphasis), OPERATORS (Saturn / 10th-house emphasis), INTEGRATORS (Mercury / Moon / 3rd-house emphasis), CONNECTORS (Venus / 7th/11th-house emphasis)
+- **Critical-path partnerships** — 3-5 pair-resonances within the team that are structurally load-bearing (without these pair-couplings, the team cannot ship). Each critical path crosses cluster boundaries to a structural purpose.
+- **Operational rhythm** — the joint dasha matrix produces an inherent operational cadence. Some quarters are scale-quarters, some are consolidate-quarters.
+- **Joint-operative archetype** — the team carries a Tarot-major-arcanum archetype as a whole. Name it.
+
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THE OUTLINE — EXACT STRUCTURE
+
+# Team Synergy Weave Map — {{subject_names}}
+
+## Role-Cluster Assignment
+
+For each member, assign one cluster (visionaries / operators / integrators / connectors) based on their chart's dominant signal. Output as a structured table:
+
+| Member | Cluster | Chart Signal (Anchor) | HD Type + Authority |
+|---|---|---|---|
+| [name] | [cluster] | [e.g. "Jupiter exalted 9th, Atmakaraka"] | [e.g. "Generator + Emotional"] |
+| ... | ... | ... | ... |
+
+Cluster summary:
+- **Visionaries:** N members — [list names]
+- **Operators:** N members — [list names]
+- **Integrators:** N members — [list names]
+- **Connectors:** N members — [list names]
+
+State which cluster has the MOST members and what that means structurally for the team's operating mode. State which cluster is UNDER-staffed (or absent) and what the team must source externally to compensate.
+
+## Critical-Path Partnerships
+
+Identify 3-5 pair-resonances within the team that are structurally load-bearing. Each critical path:
+- Crosses a cluster boundary (visionary↔operator, etc.) — same-cluster pairs are NOT critical paths; they're amplification, not coupling
+- Has a specific operational consequence (what the pair MAKES POSSIBLE that wouldn't exist without it)
+- Carries a four-way bridge: Role-cluster pair × HD-authority match × Vimshottari-overlap-state × Gene-Key-codon
+
+Output:
+
+1. **[member A] × [member B]** — [cluster-A] × [cluster-B]
+   - Operational consequence: [what they make possible]
+   - Chart bridge: [4-way braid]
+
+2. **[member C] × [member D]** — [cluster] × [cluster]
+   - ...
+
+[repeat for 3-5 critical paths]
+
+## Operational Rhythm — The Joint Dasha Matrix Cadence
+
+Plot the operational rhythm the team's joint dasha matrix produces across the next 3-5 years. Identify:
+- **Scale quarters** — windows where multiple key members are in expansion-MD (Jupiter MD, exalted-graha AD) simultaneously. These are the team's GO-quarters.
+- **Consolidate quarters** — windows where multiple key members are in contraction-MD (Saturn, debility AD). These are the team's HOLD-quarters.
+- **Pivot windows** — quarters where a critical-path partner transitions MD. These windows reconfigure the team's operating shape.
+
+Output as a quarter-by-quarter table for the next 3-5 years.
+
+## Joint-Operative Archetype
+
+State the team's Tarot-major-arcanum archetype. The team-as-system carries ONE archetypal current that none of its members carry alone. Anchor this in:
+- The most-common Atmakaraka across members
+- The dominant cluster + the under-staffed cluster's relationship
+- The joint Tarot stack from members' Sun-or-Lagna-derived Tarot keys
+
+Single sentence + 1 paragraph of justification.
+
+## Anchor Codon Ring
+
+If the team's Gene Keys spheres activate a coherent codon ring (or near-ring), name it. Codon rings carry transmission-current — what the team is structurally configured to PROPAGATE genetically-archetypally.
+
+End the OUTLINE pass. Expansion passes will execute against this map.
+
+## pass-exp1-template
+
+You are running **expansion pass 1 (Cluster Reading)** of the hierarchical team-synergy synthesis for {{subject_names}}. The OUTLINE pass has produced the weave map. Execute against it.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+The outline named role-clusters and assigned each member. This pass READS each cluster — what it brings to the team-field, where it has structural strength, where it has structural exposure.
+
+## PRIOR PASS OUTPUT (OUTLINE — the weave map)
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS EXPANSION PASS — EXACT STRUCTURE
+
+# Cluster Reading — {{subject_names}}
+
+For each of the four clusters (visionaries / operators / integrators / connectors) that has 1+ members, produce a sub-section. Mark each cluster sub-section with `<section data-cluster-section="<cluster-name>">` so the interaction layer's cluster-filter scrolls to the right place.
+
+## Visionaries
+
+*(Members: [names from outline]. If no members in this cluster, state that explicitly and decode what the team SOURCES from outside to compensate.)*
+
+For this cluster:
+
+### What the Cluster Brings to the Team-Field
+*(Each visionary member's contribution to the joint operative. Anchor each in: Jupiter placement + 9th-house signature + Atmakaraka-vision-current. What this person SEES that no one else on the team sees.)*
+
+### Cluster Strength
+*(Where multiple visionaries reinforce — same-direction Jupiter signals, shared 9th-house themes. What the cluster can do collectively that no single visionary can.)*
+
+### Cluster Exposure
+*(Where the cluster has structural friction — competing visions, Jupiter-Mars tension across members, dharma-signature divergence that needs explicit articulation. The exposure is not bad; it must be NAMED.)*
+
+### Critical-Path Couplings (referencing OUTLINE)
+*(Which critical paths from the outline involve this cluster? Where this cluster cross-couples to operators/integrators/connectors.)*
+
+## Operators
+
+*(Same structure for the operators cluster — anchored in Saturn / 10th-house / disciplinary structure.)*
+
+## Integrators
+
+*(Same structure — anchored in Mercury / Moon / 3rd-house / pattern-engine.)*
+
+## Connectors
+
+*(Same structure — anchored in Venus / 7th-11th house / relational current.)*
+
+End Pass exp1. Pass exp2 will move into the critical-path pair threads.
+
+## pass-exp2-template
+
+You are running **expansion pass 2 (Critical-Path Pair Threads)** of the hierarchical team-synergy synthesis for {{subject_names}}.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+The outline named 3-5 critical-path partnerships. This pass reads each one in depth — what the pair makes possible, where the pair's structural friction lives, how the pair feeds the joint operative.
+
+Each critical-path partnership IS a dyad-reading-mini-instance inside the larger team-field. Apply the dyadic-decoding loop to each one.
+
+## PRIOR PASS OUTPUT (OUTLINE + Cluster Reading)
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS EXPANSION PASS — EXACT STRUCTURE
+
+# Critical-Path Pair Threads — {{subject_names}}
+
+For each of the 3-5 critical-path partnerships identified in the OUTLINE, produce a sub-section.
+
+## Critical Path 1: [member A] × [member B] — [cluster pair]
+
+### The Coupling Signature
+*(Vedic: cross-chart mutual disposition between A and B. Where A's graha lands in B's chart, and vice versa, for the placements that matter most given their role-cluster pair (e.g., for visionary × operator, look at Jupiter-Saturn cross-coupling).)*
+
+### The HD Electromagnetic Channel(s)
+*(What channels A+B make as a pair that neither has alone. These are the operational capabilities the team has BECAUSE of this critical-path partnership.)*
+
+### The Vimshottari Overlap Window
+*(Plot A and B's dasha-AD overlap across the next 3-5 years. Identify the windows where both are in expansion-current simultaneously — those are the critical-path's PEAK operational windows. Identify the windows where one is in contraction — those are the partnership-stress windows.)*
+
+### The Gene Key Couplet
+*(Which Gene Keys spheres of A and B couple to make a specific transmission-current. Pearl-to-Pearl pairing, especially.)*
+
+### What This Critical Path Makes Possible
+*(Operationally specific. What the team can SHIP because A+B are paired. What would fail without this coupling.)*
+
+### Failure Mode
+*(The specific way THIS critical path can break. Tied to chart-architecture. When does it strain — under specific transits, under specific antardasha states, under specific operational pressure types?)*
+
+## Critical Path 2: [member C] × [member D] — [cluster pair]
+
+*(Same structure.)*
+
+## Critical Path 3 / 4 / 5: ...
+
+*(Same structure for each remaining critical path.)*
+
+## Critical-Path Synthesis
+
+The 3-5 critical paths together compose the team's operational skeleton. Briefly synthesize: where the skeleton is COHERENT (multiple critical paths reinforce), where it has a STRUCTURAL GAP (a cluster pair that should be cross-coupled but isn't), and what that means for the team's resilience.
+
+End Pass exp2. Pass exp3 will close with the joint operative + operational cadence.
+
+## pass-exp3-template
+
+You are running **expansion pass 3 (Joint Operative + Operational Cadence)** of the hierarchical team-synergy synthesis for {{subject_names}}. This is the keystone closing pass.
+
+**Target:** ~{{target_words}} words. **Pass title:** {{pass_title}}.
+
+The outline named the joint-operative archetype and the operational rhythm. The cluster reading mapped what each cluster brings. The critical-path threads named the structural couplings. This pass synthesizes: what does the team SHIP, when, in what sequence — and what does the team become unable to need across the next 3-5 years?
+
+## PRIOR PASS OUTPUT (OUTLINE + Clusters + Critical Paths)
+{{prior_pass}}
+
+## SUBJECT ROSTER
+{{subject_roster}}
+
+## OVERLAY RULES
+{{overlay_summary}}
+
+## BRIDGE MANDATES
+{{bridge_mandates}}
+
+---
+
+## PRODUCE THIS EXPANSION PASS — EXACT STRUCTURE
+
+# Joint Operative + Operational Cadence — {{subject_names}}
+
+## The Joint-Operative Archetype — Decoded
+
+The outline named the team's archetype. Now decode it fully:
+- The chart-architectural evidence (what specifically makes this team carry THIS archetype, not another)
+- The operational signature — what kinds of work this archetype is structurally configured to produce
+- The maturation arc — what the archetype's mature form looks like across the next 3-5 years
+
+## The Operational Cadence — Year-by-Year
+
+For each year of the next 3-5 years (the team's operating horizon — beyond that, role-clusters reconfigure as members' dashas shift):
+
+### Year [N]
+- **Scale quarters:** [which Q1-Q4 are GO quarters; why]
+- **Consolidate quarters:** [which are HOLD quarters; why]
+- **Pivot windows:** [which critical-path partners transition; what changes]
+- **What the team SHIPS this year** (specific deliverable category + scale)
+- **What the team should NOT attempt** (mismatch with the year's cadence)
+
+[Repeat for each year of the operating horizon.]
+
+## Build-Sequence Across Critical Paths
+
+How the critical-path partnerships activate over the operating horizon. Which critical path leads which year's deliverable. The sequencing of critical-path activation IS the team's build-roadmap.
+
+## Joint Anti-Dependency — What the Team Becomes Unable to Need
+
+Across the operating horizon, what does the team-field become structurally unable to need from outside? What capacity does the team internalize that it currently sources externally?
+
+This is NOT about replacing external services with internal capability. It's about the team's CHART-ARCHITECTURAL maturation: where the joint operative becomes a complete instrument that doesn't require external mediation.
+
+## The Joint AKSHARA Artifact
+
+Across the operating horizon, what visible artifact does the team-field write into the world? The imperishable seed (Anandamaya / Cl(7)) of the joint operative. Its mature form. The thing the team makes that outlasts the team's current configuration.
+
+## The Single Sentence
+
+The team in ONE sentence. A structural identity claim the reading has earned across the four passes.
+
+## The One Practice
+
+The single practice that, if held faithfully across the team, lets the team-field become a coherent instrument that doesn't require the interpreter's mediation.
+
+End Pass exp3. The full hierarchical team-synergy reading is now complete.
+
+## overlay-rules
+
+For team-synergy mode:
+- **Human Design (weight 2.0):** highest-foregrounded — HD type + authority + center-definition distribution across the team IS the structural skeleton of the joint operative.
+- **Vimshottari (weight 1.5):** secondary foreground — the joint dasha matrix produces the team's operational cadence.
+- **Gene Keys (weight 1.5):** the codon ring + spheres-of-purpose overlay — what the team transmits genetically-archetypally.
+- **Full 16-engine convergence at weight 1.0+:** team-synergy is the mode where ALL Selemene engines are operative — no single engine dominates; the team-field is multi-engine by nature.
+- **Numerology (1.0):** lifepath + expression number distribution within the team carries cohort-current signal.
+- **Enneagram (1.0):** when known, complements HD-cluster assignment.
+
+**House overlay:**
+- **10 (career / joint dharma):** primary — the team's operative is dharmic-collective.
+- **11 (community / network / joint operative):** secondary — what the team builds and who it reaches.
+- **6 (daily grind / operational obstacles):** failure-mode locus.
+- **3 (cohort / siblings / peer-network):** the team-as-cohort architecture.
+
+## glossary
+
+- **Role-cluster** — the four structural cluster types (visionaries / operators / integrators / connectors). Each member belongs to one cluster based on their chart's dominant signal.
+- **Critical-path partnership** — a pair-resonance within the team that is structurally load-bearing. Crosses cluster boundaries to a specific operational purpose.
+- **Operational cadence** — the joint dasha matrix produces scale-quarters, consolidate-quarters, and pivot windows across the team's operating horizon.
+- **Joint-operative archetype** — the team-as-system carries a Tarot-major-arcanum archetype as a WHOLE that none of its members carry alone.
+- **The outline IS the architecture** — the hierarchical pass-decomposition treats the outline pass as STRUCTURAL DATA the expansion passes execute against, not as prose.
+
+## interactions
+
+For the interactive HTML output:
+- **Cluster filter buttons** (Visionaries / Operators / Integrators / Connectors) — toggle filter dims non-matching nodes/edges/section-content. Each cluster button is color-coded by cluster.
+- **Hover a critical-path edge** in the web-graph SVG → tooltip with the partnership-card content (data-label).
+- **Dasha-cadence overlay toggle** — toggles `.dasha-cadence-overlay` bar visibility; bar scrubs as user scrolls (CSS scroll-driven animation when supported).
+
+## lessons
+
+*(No autoresearch passes yet. First Pass 6 entry (#58) will land here per the autoresearch contract — variant axis: outline-pass prompt phrasing (cluster-naming-first / role-stack-first / critical-path-first); mode-specific judge axis: "role-cluster legibility".)*

--- a/scripts/integratedreading/render/interactions/index.ts
+++ b/scripts/integratedreading/render/interactions/index.ts
@@ -224,11 +224,13 @@ export const INTERACTION_MODULES: Record<TopologyKey, InteractionModule> = {
 import { partnerSynastryModule } from './partner-synastry.js';
 import { businessPartnersModule } from './business-partners.js';
 import { familyPentaModule } from './family-penta.js';
+import { teamSynergyModule } from './team-synergy.js';
 
 export const MODE_INTERACTION_MODULES: Record<string, InteractionModule> = {
   'partner-synastry': partnerSynastryModule,
   'business-partners': businessPartnersModule,
   'family-penta': familyPentaModule,
+  'team-synergy': teamSynergyModule,
 };
 
 // ────────────────────────────────────────────────────────────────────────

--- a/scripts/integratedreading/render/interactions/team-synergy.ts
+++ b/scripts/integratedreading/render/interactions/team-synergy.ts
@@ -1,0 +1,230 @@
+// ─── Team-Synergy mode interactions ────────────────────────────────────
+// Layers on top of web-graph topology. Affordances:
+//   - Cluster filter (toggle buttons per role-cluster) — dims non-matching
+//     nodes/edges/section-content
+//   - Critical-path edge hover → partnership card with data-label content
+//   - Dasha-cadence overlay toggle — animates operational rhythm bar
+//
+// Per design doc § 5 — Team-Synergy affordances row.
+// P5.3 deliverable. Closes #54.
+
+import type { InteractionModule } from './index.js';
+
+export const teamSynergyModule: InteractionModule = {
+  scrollTimelineCss: `
+/* ════ Team-Synergy mode interactions ═════════════════════════════════ */
+
+/* Cluster filter buttons — placed near the web-graph SVG */
+.canvas.interactive[data-mode="team-synergy"] .cluster-filter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 24px auto;
+  justify-content: center;
+  font-family: var(--font-mono);
+  font-size: 9pt;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+}
+.canvas.interactive[data-mode="team-synergy"] .cluster-filter button {
+  background: transparent;
+  border: 1px solid currentColor;
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  font: inherit;
+  letter-spacing: inherit;
+  opacity: 0.7;
+}
+.canvas.interactive[data-mode="team-synergy"] .cluster-filter button:hover {
+  opacity: 1;
+  background: currentColor;
+  color: var(--void-black);
+}
+.canvas.interactive[data-mode="team-synergy"] .cluster-filter button[data-active="true"] {
+  opacity: 1;
+  background: currentColor;
+  color: var(--void-black);
+}
+.canvas.interactive[data-mode="team-synergy"] .cluster-filter button[data-cluster="visionaries"] { color: #E8B923; }
+.canvas.interactive[data-mode="team-synergy"] .cluster-filter button[data-cluster="operators"] { color: #5A7090; }
+.canvas.interactive[data-mode="team-synergy"] .cluster-filter button[data-cluster="integrators"] { color: var(--coherence-emerald); }
+.canvas.interactive[data-mode="team-synergy"] .cluster-filter button[data-cluster="connectors"] { color: #D4A8FF; }
+
+/* When a cluster filter is active, dim non-matching SVG elements + section content */
+.canvas.interactive[data-mode="team-synergy"][data-cluster-filter]
+  .viz svg [data-cluster-node]:not([data-cluster-node*=":matchsvg:"]),
+.canvas.interactive[data-mode="team-synergy"][data-cluster-filter]
+  .viz svg [data-cluster]:not([data-cluster*=":matchsvg:"]) {
+  opacity: 0.18;
+  transition: opacity 0.3s ease;
+}
+.canvas.interactive[data-mode="team-synergy"][data-cluster-filter]
+  .viz svg [data-cluster-node][data-cluster-active] {
+  opacity: 1;
+}
+.canvas.interactive[data-mode="team-synergy"][data-cluster-filter]
+  section[data-cluster-section]:not([data-cluster-active]) {
+  opacity: 0.35;
+  transition: opacity 0.3s ease;
+}
+
+/* Critical-path edges — hoverable */
+.canvas.interactive[data-mode="team-synergy"] .viz svg line[data-critical="true"] {
+  cursor: pointer;
+  transition: stroke-width 0.3s ease, filter 0.3s ease;
+}
+.canvas.interactive[data-mode="team-synergy"] .viz svg line[data-critical="true"]:hover {
+  stroke-width: 3 !important;
+  filter: drop-shadow(0 0 8px var(--sacred-gold));
+}
+
+/* Background (non-critical) edges — also stay non-interactive */
+.canvas.interactive[data-mode="team-synergy"] .viz svg line[data-critical="false"] {
+  pointer-events: none;
+}
+
+/* Dasha-cadence overlay bar — toggleable */
+.canvas.interactive[data-mode="team-synergy"] .dasha-cadence-overlay {
+  --cadence-progress: 0;
+  position: relative;
+  height: 28px;
+  margin: 24px 0;
+  border: 1px solid rgba(197,160,23,0.2);
+  display: none;
+}
+.canvas.interactive[data-mode="team-synergy"][data-cadence-on] .dasha-cadence-overlay {
+  display: block;
+}
+.canvas.interactive[data-mode="team-synergy"] .dasha-cadence-overlay::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(90deg,
+    var(--coherence-emerald) 0%,
+    var(--sacred-gold) calc(var(--cadence-progress) * 1%),
+    rgba(197,160,23,0.08) calc(var(--cadence-progress) * 1%),
+    rgba(197,160,23,0.08) 100%);
+  transition: background 0.4s ease;
+}
+
+@supports (animation-timeline: scroll()) {
+  .canvas.interactive[data-mode="team-synergy"][data-cadence-on] .dasha-cadence-overlay {
+    animation: dasha-cadence-fill linear both;
+    animation-timeline: scroll(root);
+    animation-range: 20% 80%;
+  }
+  @keyframes dasha-cadence-fill {
+    from { --cadence-progress: 0; }
+    to   { --cadence-progress: 100; }
+  }
+}
+`,
+
+  gsapTimeline: `
+// Team-Synergy — cluster bounding hulls fade in first, then nodes, then critical edges
+if (typeof gsap !== 'undefined' && typeof ScrollTrigger !== 'undefined') {
+  document.querySelectorAll('.canvas.interactive[data-mode="team-synergy"] .viz svg').forEach(function(svg) {
+    var hulls = svg.querySelectorAll('[data-cluster]:not([data-cluster-label])');
+    var nodes = svg.querySelectorAll('circle[data-node]');
+    var critical = svg.querySelectorAll('line[data-critical="true"]');
+    if (nodes.length === 0) return;
+
+    var tl = gsap.timeline({
+      scrollTrigger: {
+        trigger: svg,
+        start: 'top 75%',
+        toggleActions: 'play none none reverse',
+      },
+    });
+
+    if (hulls.length > 0) {
+      tl.from(hulls, { opacity: 0, duration: 0.6, stagger: 0.1, ease: 'power2.out' });
+    }
+    tl.from(nodes, {
+      scale: 0, opacity: 0,
+      duration: 0.5, stagger: 0.05, ease: 'back.out(1.6)',
+      transformOrigin: 'center', transformBox: 'fill-box',
+    }, '-=0.3');
+    if (critical.length > 0) {
+      tl.from(critical, { opacity: 0, duration: 0.7, stagger: 0.08, ease: 'power2.out' }, '-=0.4');
+    }
+  });
+}
+`,
+
+  eventHandlers: `
+// Team-Synergy — cluster filter + critical-edge hover-card + cadence toggle
+(function() {
+  var canvas = document.querySelector('.canvas.interactive[data-mode="team-synergy"]');
+  if (!canvas) return;
+
+  // ── Cluster filter (multi-toggle: clicking a 2nd cluster clears the 1st) ──
+  var clusterButtons = canvas.querySelectorAll('.cluster-filter button[data-cluster]');
+  clusterButtons.forEach(function(btn) {
+    btn.addEventListener('click', function() {
+      var cluster = btn.getAttribute('data-cluster');
+      var currentlyActive = btn.getAttribute('data-active') === 'true';
+      // Single-select filter — clear all first
+      clusterButtons.forEach(function(b) { b.setAttribute('data-active', 'false'); });
+
+      if (currentlyActive) {
+        canvas.removeAttribute('data-cluster-filter');
+        clearClusterMarks();
+      } else {
+        btn.setAttribute('data-active', 'true');
+        canvas.setAttribute('data-cluster-filter', cluster || '');
+        applyClusterMarks(cluster);
+      }
+    });
+  });
+
+  function clearClusterMarks() {
+    canvas.querySelectorAll('[data-cluster-active]').forEach(function(el) {
+      el.removeAttribute('data-cluster-active');
+    });
+  }
+  function applyClusterMarks(cluster) {
+    clearClusterMarks();
+    if (!cluster) return;
+    canvas.querySelectorAll('[data-cluster-node="' + cluster + '"]').forEach(function(el) {
+      el.setAttribute('data-cluster-active', 'true');
+    });
+    canvas.querySelectorAll('[data-cluster="' + cluster + '"]').forEach(function(el) {
+      el.setAttribute('data-cluster-active', 'true');
+    });
+    canvas.querySelectorAll('section[data-cluster-section="' + cluster + '"]').forEach(function(el) {
+      el.setAttribute('data-cluster-active', 'true');
+    });
+  }
+
+  // ── Critical-path edge hover → tooltip with partnership card content ──
+  canvas.querySelectorAll('.viz svg line[data-critical="true"]').forEach(function(line) {
+    var label = line.getAttribute('data-label') || 'Critical-path partnership';
+    line.addEventListener('mouseenter', function(e) {
+      if (typeof window.showBridgeTooltip === 'function') {
+        window.showBridgeTooltip(e, 'CRITICAL PATH · ' + label);
+      }
+    });
+    line.addEventListener('mouseleave', function() {
+      if (window.hideBridgeTooltip) window.hideBridgeTooltip();
+    });
+  });
+
+  // ── Dasha-cadence overlay toggle ────────────────────────────────────
+  var cadenceToggle = canvas.querySelector('.cadence-toggle');
+  if (cadenceToggle) {
+    cadenceToggle.addEventListener('click', function() {
+      var on = canvas.getAttribute('data-cadence-on') !== null;
+      if (on) {
+        canvas.removeAttribute('data-cadence-on');
+        cadenceToggle.setAttribute('data-active', 'false');
+      } else {
+        canvas.setAttribute('data-cadence-on', '');
+        cadenceToggle.setAttribute('data-active', 'true');
+      }
+    });
+  }
+})();
+`,
+};

--- a/scripts/integratedreading/render/svg/index.ts
+++ b/scripts/integratedreading/render/svg/index.ts
@@ -13,6 +13,7 @@ import type { TopologyKey } from '../../modes/parser.js';
 import { renderCompositeResonance, type CompositeResonanceData } from './composite-resonance.js';
 import { renderCompositeTriad, type CompositeTriadData } from './composite-triad.js';
 import { renderCompositePenta, type CompositePentaData } from './composite-penta.js';
+import { renderTeamWeb, type TeamWebData } from './team-web.js';
 
 // ────────────────────────────────────────────────────────────────────────
 // Renderer function shape
@@ -45,10 +46,6 @@ class NotImplementedError extends Error {
   }
 }
 
-function webGraphStub(_data: any, _opts?: RendererOpts): string {
-  throw new NotImplementedError('web-graph', 'issue #53 (P5.2)');
-}
-
 // ────────────────────────────────────────────────────────────────────────
 // Registry
 // ────────────────────────────────────────────────────────────────────────
@@ -57,7 +54,7 @@ export const TOPOLOGY_RENDERERS: Record<TopologyKey, RendererFn<any>> = {
   'dyad-arc': renderCompositeResonance as RendererFn<CompositeResonanceData>,
   'triad-triangle': renderCompositeTriad as RendererFn<CompositeTriadData>,
   'pentagon': renderCompositePenta as RendererFn<CompositePentaData>,
-  'web-graph': webGraphStub,
+  'web-graph': renderTeamWeb as RendererFn<TeamWebData>,
 };
 
 // ────────────────────────────────────────────────────────────────────────
@@ -99,3 +96,4 @@ export type { TopologyKey } from '../../modes/parser.js';
 export { renderCompositeResonance, type CompositeResonanceData } from './composite-resonance.js';
 export { renderCompositeTriad, type CompositeTriadData, type TriadSubject } from './composite-triad.js';
 export { renderCompositePenta, type CompositePentaData, type PentaSubject } from './composite-penta.js';
+export { renderTeamWeb, type TeamWebData, type TeamMember, type CriticalPathEdge, type RoleCluster } from './team-web.js';

--- a/scripts/integratedreading/render/svg/team-web.ts
+++ b/scripts/integratedreading/render/svg/team-web.ts
@@ -1,0 +1,392 @@
+// ─── SVG: Team Web — N-Subject Role-Clustered Force Graph ──────────────
+// Force-directed-style layout with DETERMINISTIC precomputed positions
+// (print-stable, no animation needed). Nodes are grouped by role-cluster
+// and placed on a circle, with each cluster occupying a contiguous arc.
+// Critical-path partnership edges render prominently; non-critical edges
+// render as faint background lines. Each cluster has a translucent
+// bounding hull. Center carries the joint-operative archetype label.
+//
+// Per design doc § 5 — `web-graph` topology renderer.
+// P5.2 deliverable. Closes #53.
+
+import { BRAND } from '../styles.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// Types
+// ────────────────────────────────────────────────────────────────────────
+
+export type RoleCluster = 'visionaries' | 'operators' | 'integrators' | 'connectors';
+
+export interface TeamMember {
+  name: string;
+  /** Role-cluster assignment. Determines color + cluster placement. */
+  role_cluster: RoleCluster;
+  /** Optional — hex color override. Falls back to cluster-color. */
+  color?: string;
+  current_mahadasha_lord?: string;
+  next_mahadasha_lord?: string;
+  next_mahadasha_iso?: string;
+}
+
+export interface CriticalPathEdge {
+  /** Indices into the members[] array. */
+  a: number;
+  b: number;
+  /** Resonance strength 0-1; renders thicker for higher values. */
+  weight?: number;
+  /** Optional short label describing the partnership. */
+  label?: string;
+}
+
+export interface TeamWebData {
+  members: TeamMember[];
+  /** 3-5 critical-path partnerships identified by the outline pass. */
+  critical_path_edges?: CriticalPathEdge[];
+  /** Joint-operative archetype name shown at center (e.g., "The Cauldron"). */
+  joint_operative_archetype?: string;
+  /** Optional themes that recur across the team — bedrock currents. */
+  shared_keys?: string[];
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Constants
+// ────────────────────────────────────────────────────────────────────────
+
+const CLUSTER_COLORS: Record<RoleCluster, string> = {
+  visionaries: '#E8B923',   // jupiter-gold
+  operators:   '#5A7090',   // saturn-slate
+  integrators: BRAND.coherenceEmerald,
+  connectors:  '#D4A8FF',   // venus-violet
+};
+
+const CLUSTER_DISPLAY: Record<RoleCluster, string> = {
+  visionaries: 'VISIONARIES',
+  operators:   'OPERATORS',
+  integrators: 'INTEGRATORS',
+  connectors:  'CONNECTORS',
+};
+
+const CLUSTER_ORDER: RoleCluster[] = ['visionaries', 'operators', 'integrators', 'connectors'];
+
+// ────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────
+
+function formatPivot(iso?: string): string {
+  if (!iso) return '';
+  const m = iso.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (!m) return iso.slice(0, 10);
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+  return `${parseInt(m[3], 10)} ${months[parseInt(m[2], 10) - 1]} ${m[1]}`;
+}
+
+/**
+ * Convex hull of a set of points using the gift-wrapping (Jarvis march)
+ * algorithm. Simple, deterministic, fine for 1-12 input points.
+ */
+function convexHull(points: Array<{ x: number; y: number }>): Array<{ x: number; y: number }> {
+  if (points.length < 3) return [...points];
+
+  // Start with the leftmost point
+  let start = 0;
+  for (let i = 1; i < points.length; i++) {
+    if (points[i].x < points[start].x ||
+        (points[i].x === points[start].x && points[i].y < points[start].y)) {
+      start = i;
+    }
+  }
+
+  const hull: Array<{ x: number; y: number }> = [];
+  let current = start;
+  do {
+    hull.push(points[current]);
+    let next = (current + 1) % points.length;
+    for (let i = 0; i < points.length; i++) {
+      // Cross product: positive = counter-clockwise turn
+      const o = (points[next].x - points[current].x) * (points[i].y - points[current].y) -
+                (points[next].y - points[current].y) * (points[i].x - points[current].x);
+      if (o < 0) next = i;
+    }
+    current = next;
+  } while (current !== start && hull.length < points.length);
+
+  return hull;
+}
+
+/**
+ * Inflate a polygon outward from its centroid by `padding` pixels.
+ * Gives the cluster bounding hull some breathing room around its nodes.
+ */
+function inflateHull(hull: Array<{ x: number; y: number }>, padding: number): Array<{ x: number; y: number }> {
+  if (hull.length === 0) return hull;
+  const cx = hull.reduce((s, p) => s + p.x, 0) / hull.length;
+  const cy = hull.reduce((s, p) => s + p.y, 0) / hull.length;
+  return hull.map((p) => {
+    const dx = p.x - cx;
+    const dy = p.y - cy;
+    const len = Math.sqrt(dx * dx + dy * dy);
+    if (len === 0) return p;
+    return {
+      x: p.x + (dx / len) * padding,
+      y: p.y + (dy / len) * padding,
+    };
+  });
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Renderer
+// ────────────────────────────────────────────────────────────────────────
+
+export function renderTeamWeb(data: TeamWebData, opts: { width?: number } = {}): string {
+  const W = opts.width ?? 880;
+  const H = W;
+  const cx = W / 2, cy = H / 2 + 12;
+  const fieldR = W * 0.36;
+
+  if (data.members.length < 2 || data.members.length > 12) {
+    throw new Error(`team-web requires 2-12 members, got ${data.members.length}`);
+  }
+
+  // ── Group members by cluster ─────────────────────────────────────────
+  // Preserve original index for edge references; group ordering follows
+  // CLUSTER_ORDER for visual stability across runs.
+  const grouped: Record<RoleCluster, Array<{ member: TeamMember; idx: number }>> = {
+    visionaries: [], operators: [], integrators: [], connectors: [],
+  };
+  for (let i = 0; i < data.members.length; i++) {
+    const m = data.members[i];
+    if (!grouped[m.role_cluster]) {
+      // unknown cluster — coerce to connectors as a sensible default
+      grouped.connectors.push({ member: { ...m, role_cluster: 'connectors' }, idx: i });
+    } else {
+      grouped[m.role_cluster].push({ member: m, idx: i });
+    }
+  }
+  const activeClusters = CLUSTER_ORDER.filter((c) => grouped[c].length > 0);
+  const totalNodes = data.members.length;
+
+  // ── Place nodes on a circle, each cluster occupying a contiguous arc ─
+  // Cluster arc-span proportional to cluster size; small gap between clusters.
+  const gapAngle = (Math.PI / 30);  // ~6° gap between clusters
+  const totalGap = gapAngle * activeClusters.length;
+  const availableArc = (2 * Math.PI) - totalGap;
+
+  const positions: Array<{ x: number; y: number; cluster: RoleCluster; idx: number }> = [];
+  let angleCursor = -Math.PI / 2;   // start at top
+
+  for (const cluster of activeClusters) {
+    const clusterNodes = grouped[cluster];
+    const clusterArcShare = (clusterNodes.length / totalNodes) * availableArc;
+    // If the cluster has only 1 node, place it at its arc center; otherwise distribute.
+    if (clusterNodes.length === 1) {
+      const a = angleCursor + clusterArcShare / 2;
+      positions[clusterNodes[0].idx] = {
+        x: cx + fieldR * Math.cos(a),
+        y: cy + fieldR * Math.sin(a),
+        cluster,
+        idx: clusterNodes[0].idx,
+      };
+    } else {
+      const step = clusterArcShare / (clusterNodes.length - 1);
+      for (let i = 0; i < clusterNodes.length; i++) {
+        const a = angleCursor + step * i;
+        positions[clusterNodes[i].idx] = {
+          x: cx + fieldR * Math.cos(a),
+          y: cy + fieldR * Math.sin(a),
+          cluster,
+          idx: clusterNodes[i].idx,
+        };
+      }
+    }
+    angleCursor += clusterArcShare + gapAngle;
+  }
+
+  // ── Cluster bounding hulls (translucent fill behind nodes) ───────────
+  const clusterHulls = activeClusters.map((cluster) => {
+    const nodes = grouped[cluster].map((g) => positions[g.idx]);
+    if (nodes.length === 0) return '';
+    const color = CLUSTER_COLORS[cluster];
+    // For 1-2 nodes, draw a circle around them; for 3+, draw the convex hull.
+    if (nodes.length === 1) {
+      return `<circle cx="${nodes[0].x}" cy="${nodes[0].y}" r="44"
+              fill="${color}" fill-opacity="0.08" stroke="${color}" stroke-width="0.5"
+              stroke-opacity="0.35" data-cluster="${cluster}"/>`;
+    }
+    if (nodes.length === 2) {
+      const mx = (nodes[0].x + nodes[1].x) / 2;
+      const my = (nodes[0].y + nodes[1].y) / 2;
+      const dx = nodes[1].x - nodes[0].x;
+      const dy = nodes[1].y - nodes[0].y;
+      const r = Math.sqrt(dx * dx + dy * dy) / 2 + 36;
+      return `<circle cx="${mx}" cy="${my}" r="${r}"
+              fill="${color}" fill-opacity="0.07" stroke="${color}" stroke-width="0.5"
+              stroke-opacity="0.3" data-cluster="${cluster}"/>`;
+    }
+    const hull = inflateHull(convexHull(nodes), 28);
+    const d = hull.map((p, i) => `${i === 0 ? 'M' : 'L'} ${p.x} ${p.y}`).join(' ') + ' Z';
+    return `<path d="${d}" fill="${color}" fill-opacity="0.07"
+            stroke="${color}" stroke-width="0.5" stroke-opacity="0.3"
+            data-cluster="${cluster}"/>`;
+  }).join('');
+
+  // ── Cluster labels (positioned at the arc midpoint, outside fieldR) ─
+  let clusterLabelAngleCursor = -Math.PI / 2;
+  const clusterLabels = activeClusters.map((cluster) => {
+    const clusterNodes = grouped[cluster];
+    const clusterArcShare = (clusterNodes.length / totalNodes) * availableArc;
+    const midA = clusterLabelAngleCursor + clusterArcShare / 2;
+    clusterLabelAngleCursor += clusterArcShare + gapAngle;
+
+    const labelR = fieldR + 78;
+    const lx = cx + labelR * Math.cos(midA);
+    const ly = cy + labelR * Math.sin(midA);
+    let anchor: 'start' | 'middle' | 'end' = 'middle';
+    if (Math.cos(midA) > 0.3) anchor = 'start';
+    else if (Math.cos(midA) < -0.3) anchor = 'end';
+
+    return `
+      <text x="${lx}" y="${ly}" text-anchor="${anchor}"
+            font-family="SF Mono, monospace" font-size="9" font-weight="700"
+            fill="${CLUSTER_COLORS[cluster]}" letter-spacing="0.32em"
+            data-cluster-label="${cluster}">${CLUSTER_DISPLAY[cluster]}</text>
+      <text x="${lx}" y="${ly + 14}" text-anchor="${anchor}"
+            font-family="SF Mono, monospace" font-size="7"
+            fill="${BRAND.mutedSilver}" letter-spacing="0.22em" opacity="0.7">${clusterNodes.length} MEMBER${clusterNodes.length === 1 ? '' : 'S'}</text>`;
+  }).join('');
+
+  // ── Non-critical edges (faint background — every pair gets one) ──────
+  const criticalSet = new Set(
+    (data.critical_path_edges ?? []).map(
+      (e) => `${Math.min(e.a, e.b)}-${Math.max(e.a, e.b)}`,
+    ),
+  );
+  const backgroundEdges: string[] = [];
+  for (let i = 0; i < data.members.length; i++) {
+    for (let j = i + 1; j < data.members.length; j++) {
+      const key = `${i}-${j}`;
+      if (criticalSet.has(key)) continue;   // skip — critical edges drawn separately
+      const a = positions[i], b = positions[j];
+      if (!a || !b) continue;
+      backgroundEdges.push(`<line x1="${a.x}" y1="${a.y}" x2="${b.x}" y2="${b.y}"
+                  stroke="${BRAND.mutedSilver}" stroke-width="0.3"
+                  stroke-opacity="0.1" data-edge="${i}-${j}" data-critical="false"/>`);
+    }
+  }
+
+  // ── Critical-path edges (luminous gradient, weighted) ─────────────────
+  const criticalEdges = (data.critical_path_edges ?? []).map((edge, idx) => {
+    const a = positions[edge.a], b = positions[edge.b];
+    if (!a || !b) return '';
+    const weight = Math.max(0.2, Math.min(1, edge.weight ?? 0.8));
+    const strokeW = 1 + weight * 1.5;
+    const ca = CLUSTER_COLORS[a.cluster];
+    const cb = CLUSTER_COLORS[b.cluster];
+    const gradId = `team-edge-${idx}`;
+    const label = edge.label ?? '';
+    return `
+      <defs>
+        <linearGradient id="${gradId}" x1="${a.x}" y1="${a.y}" x2="${b.x}" y2="${b.y}" gradientUnits="userSpaceOnUse">
+          <stop offset="0%" stop-color="${ca}" stop-opacity="0.7"/>
+          <stop offset="50%" stop-color="${BRAND.sacredGold}" stop-opacity="0.75"/>
+          <stop offset="100%" stop-color="${cb}" stop-opacity="0.7"/>
+        </linearGradient>
+      </defs>
+      <line x1="${a.x}" y1="${a.y}" x2="${b.x}" y2="${b.y}"
+            stroke="${BRAND.sacredGold}" stroke-width="${strokeW + 1.5}" stroke-opacity="0.1"
+            data-edge="${edge.a}-${edge.b}" data-critical="glow"/>
+      <line x1="${a.x}" y1="${a.y}" x2="${b.x}" y2="${b.y}"
+            stroke="url(#${gradId})" stroke-width="${strokeW}"
+            data-edge="${edge.a}-${edge.b}" data-critical="true"
+            data-label="${label.replace(/"/g, '&quot;')}"/>`;
+  }).join('');
+
+  // ── Nodes (member circles + name labels) ─────────────────────────────
+  const nodeRadius = totalNodes > 8 ? 12 : 16;
+  const nodes = positions.map((p, i) => {
+    const m = data.members[i];
+    if (!p) return '';
+    const color = m.color ?? CLUSTER_COLORS[p.cluster];
+    const mdLine = m.current_mahadasha_lord && m.next_mahadasha_lord
+      ? `${m.current_mahadasha_lord.slice(0, 3).toUpperCase()}→${m.next_mahadasha_lord.slice(0, 3).toUpperCase()}`
+      : '';
+    const pivot = formatPivot(m.next_mahadasha_iso);
+
+    // Label radial anchor — push outward from center
+    const angleFromCenter = Math.atan2(p.y - cy, p.x - cx);
+    const labelDist = nodeRadius + 18;
+    const lx = p.x + labelDist * Math.cos(angleFromCenter);
+    const ly = p.y + labelDist * Math.sin(angleFromCenter);
+    let anchor: 'start' | 'middle' | 'end' = 'middle';
+    if (Math.cos(angleFromCenter) > 0.25) anchor = 'start';
+    else if (Math.cos(angleFromCenter) < -0.25) anchor = 'end';
+
+    return `
+      <!-- node ${i} (${p.cluster}) -->
+      <circle cx="${p.x}" cy="${p.y}" r="${nodeRadius + 5}"
+              fill="${color}" fill-opacity="0.15" stroke="none"
+              data-node="${i}" data-cluster-node="${p.cluster}"/>
+      <circle cx="${p.x}" cy="${p.y}" r="${nodeRadius}"
+              fill="${BRAND.voidBlack}" stroke="${color}" stroke-width="1.5"
+              data-node="${i}" data-cluster-node="${p.cluster}"/>
+      <circle cx="${p.x}" cy="${p.y}" r="${nodeRadius - 5}"
+              fill="${color}" fill-opacity="0.4"/>
+      <text x="${lx}" y="${ly - 4}" text-anchor="${anchor}"
+            font-family="Panchang, serif" font-weight="700" font-size="11"
+            fill="${color}" letter-spacing="0.04em">${m.name}</text>
+      ${mdLine ? `<text x="${lx}" y="${ly + 8}" text-anchor="${anchor}"
+            font-family="SF Mono, monospace" font-size="6.5"
+            fill="${BRAND.mutedSilver}" letter-spacing="0.16em">${mdLine}</text>` : ''}
+      ${pivot ? `<text x="${lx}" y="${ly + 18}" text-anchor="${anchor}"
+            font-family="Panchang, serif" font-style="italic" font-size="7"
+            fill="${BRAND.sacredGold}">${pivot}</text>` : ''}`;
+  }).join('');
+
+  // ── Center seed: joint-operative archetype label ─────────────────────
+  const archetype = data.joint_operative_archetype || 'TEAM FIELD';
+  const center = `
+    <circle cx="${cx}" cy="${cy}" r="56"
+            fill="${BRAND.voidBlack}" stroke="${BRAND.sacredGold}" stroke-width="1.2"/>
+    <circle cx="${cx}" cy="${cy}" r="42"
+            fill="none" stroke="${BRAND.sacredGold}" stroke-width="0.4" opacity="0.4"/>
+    <circle cx="${cx}" cy="${cy}" r="28"
+            fill="none" stroke="${BRAND.sacredGold}" stroke-width="0.3" opacity="0.3"/>
+    <text x="${cx}" y="${cy - 6}" text-anchor="middle"
+          font-family="Panchang, serif" font-size="10" font-weight="700"
+          fill="${BRAND.sacredGold}" letter-spacing="0.18em">JOINT</text>
+    <text x="${cx}" y="${cy + 8}" text-anchor="middle"
+          font-family="Panchang, serif" font-size="10" font-weight="700"
+          fill="${BRAND.sacredGold}" letter-spacing="0.18em">OPERATIVE</text>
+    ${archetype !== 'TEAM FIELD' ? `<text x="${cx}" y="${cy + 22}" text-anchor="middle"
+          font-family="SF Mono, monospace" font-size="6.5"
+          fill="${BRAND.mutedSilver}" letter-spacing="0.22em">${archetype.toUpperCase()}</text>` : ''}`;
+
+  // ── Shared keys legend ───────────────────────────────────────────────
+  const sharedLegend = data.shared_keys && data.shared_keys.length > 0 ? `
+    <text x="${cx}" y="${H - 40}" text-anchor="middle"
+          font-family="SF Mono, monospace" font-size="7.5"
+          fill="${BRAND.mutedSilver}" letter-spacing="0.32em">SHARED OPERATIONAL CURRENTS</text>
+    <text x="${cx}" y="${H - 20}" text-anchor="middle"
+          font-family="Panchang, serif" font-size="11" font-style="italic" font-weight="500"
+          fill="${BRAND.sacredGold}" letter-spacing="0.01em">${data.shared_keys.join('   ·   ')}</text>` : '';
+
+  return `
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ${W} ${H}" width="100%" preserveAspectRatio="xMidYMid meet">
+  <defs>
+    <radialGradient id="team-bg" cx="0.5" cy="0.5" r="0.5">
+      <stop offset="0%" stop-color="${BRAND.sacredGold}" stop-opacity="0.05"/>
+      <stop offset="60%" stop-color="${BRAND.witnessViolet}" stop-opacity="0.03"/>
+      <stop offset="100%" stop-color="${BRAND.voidBlack}" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="${W}" height="${H}" fill="url(#team-bg)"/>
+  ${clusterHulls}
+  ${backgroundEdges.join('')}
+  ${criticalEdges}
+  ${nodes}
+  ${clusterLabels}
+  ${center}
+  ${sharedLegend}
+</svg>`;
+}
+
+export { CLUSTER_COLORS, CLUSTER_DISPLAY, CLUSTER_ORDER };

--- a/tests/mode-parser.test.ts
+++ b/tests/mode-parser.test.ts
@@ -350,10 +350,18 @@ describe('SVG renderer-dispatcher', () => {
     assert.match(svg, /LINEAGE/);
   });
 
-  it('web-graph topology throws NotImplementedError pointing to issue #53', () => {
-    assert.throws(
-      () => renderByTopology('web-graph', {}),
-      /not yet implemented.*#53/,
-    );
+  it('web-graph topology renders (P5.2 #53 landed)', () => {
+    // After PR #53, web-graph is a real renderer. Smoke-test it returns SVG.
+    const fakeTeam = {
+      members: Array.from({ length: 5 }, (_, i) => ({
+        name: `M${i}`,
+        role_cluster: (['visionaries', 'operators', 'integrators', 'connectors'] as const)[i % 4],
+      })),
+      critical_path_edges: [{ a: 0, b: 1, weight: 0.8 }],
+      shared_keys: [],
+    } as any;
+    const svg = renderByTopology('web-graph', fakeTeam, { width: 880 });
+    assert.match(svg, /<svg xmlns/);
+    assert.match(svg, /JOINT/);
   });
 });

--- a/tests/team-synergy.test.ts
+++ b/tests/team-synergy.test.ts
@@ -1,0 +1,319 @@
+// ─── P5 — Team-Synergy tests ───────────────────────────────────────────
+// Covers #52 (team-synergy.md), #53 (team-web.ts), #54 (interaction).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+import { parseModeDoc } from '../scripts/integratedreading/modes/parser.js';
+import {
+  TOPOLOGY_RENDERERS,
+  renderByTopology,
+  renderTeamWeb,
+} from '../scripts/integratedreading/render/svg/index.js';
+import {
+  MODE_INTERACTION_MODULES,
+  buildInteractionPayload,
+} from '../scripts/integratedreading/render/interactions/index.js';
+import { renderInteractiveHTMLPage, type PartBlock } from '../scripts/integratedreading/render/templates.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// Mode doc parses (P5.1 #52)
+// ────────────────────────────────────────────────────────────────────────
+
+describe('team-synergy mode doc (P5.1)', () => {
+  const path = resolve('scripts/integratedreading/modes/team-synergy.md');
+
+  it('parses without errors', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.mode, 'team-synergy');
+  });
+
+  it('accepts 4-12 subjects', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.subject_count.min, 4);
+    assert.equal(doc.frontmatter.subject_count.max, 12);
+  });
+
+  it('uses hierarchical architecture (outline + expansion)', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.architecture, 'hierarchical');
+  });
+
+  it('declares 4 passes (outline + 3 expansion)', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.pass_plan.length, 4);
+    assert.deepEqual(
+      doc.frontmatter.pass_plan.map((p) => p.id),
+      ['outline', 'exp1', 'exp2', 'exp3'],
+    );
+  });
+
+  it('outline pass is shorter than expansion passes', () => {
+    const doc = parseModeDoc(path);
+    const outline = doc.frontmatter.pass_plan[0];
+    const expansions = doc.frontmatter.pass_plan.slice(1);
+    for (const exp of expansions) {
+      assert.ok(outline.target_words < exp.target_words, `outline (${outline.target_words}) should be < ${exp.id} (${exp.target_words})`);
+    }
+  });
+
+  it('targets 12.5-15k words total', () => {
+    const doc = parseModeDoc(path);
+    const sum = doc.frontmatter.pass_plan.reduce((s, p) => s + p.target_words, 0);
+    assert.ok(sum >= 12500, `total = ${sum}, expected >= 12500`);
+    assert.ok(sum <= 15000, `total = ${sum}, expected <= 15000`);
+  });
+
+  it('foregrounds human-design at weight 2.0', () => {
+    const doc = parseModeDoc(path);
+    assert.ok(doc.frontmatter.engine_overlay_weights['human-design'] >= 2.0);
+  });
+
+  it('declares house_overlay includes 10 (joint dharma) and 11 (joint operative)', () => {
+    const doc = parseModeDoc(path);
+    assert.ok(doc.frontmatter.house_overlay.includes(10));
+    assert.ok(doc.frontmatter.house_overlay.includes(11));
+  });
+
+  it('declares svg_topology: web-graph', () => {
+    const doc = parseModeDoc(path);
+    assert.equal(doc.frontmatter.svg_topology, 'web-graph');
+  });
+
+  it('every pass template resolves to a body section', () => {
+    const doc = parseModeDoc(path);
+    for (const pass of doc.frontmatter.pass_plan) {
+      assert.ok(doc.sections[pass.template], `missing section: ${pass.template}`);
+    }
+  });
+
+  it('bridge mandate names role-cluster + HD-authority + Vimshottari + Gene-Key-codon', () => {
+    const doc = parseModeDoc(path);
+    const m = doc.frontmatter.bridge_mandates[0];
+    assert.match(m, /[Rr]ole-cluster/);
+    assert.match(m, /HD|authority/);
+    assert.match(m, /Vimshottari|dasha/i);
+    assert.match(m, /Gene[ -]Key|codon/i);
+  });
+
+  it('declares the outline pass as STRUCTURAL DATA, not prose', () => {
+    const doc = parseModeDoc(path);
+    const outlineTemplate = doc.sections['pass-outline-template'];
+    assert.match(outlineTemplate, /STRUCTURAL|weave map|outline IS/i);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Web-graph SVG renderer (P5.2 #53)
+// ────────────────────────────────────────────────────────────────────────
+
+const SIX_MEMBERS_DATA = {
+  members: [
+    { name: 'A', role_cluster: 'visionaries' as const, current_mahadasha_lord: 'Jupiter', next_mahadasha_lord: 'Saturn', next_mahadasha_iso: '2027-03-15' },
+    { name: 'B', role_cluster: 'visionaries' as const },
+    { name: 'C', role_cluster: 'operators' as const },
+    { name: 'D', role_cluster: 'operators' as const },
+    { name: 'E', role_cluster: 'integrators' as const },
+    { name: 'F', role_cluster: 'connectors' as const },
+  ],
+  critical_path_edges: [
+    { a: 0, b: 2, weight: 0.9, label: 'Vision × Ops handoff' },
+    { a: 1, b: 4, weight: 0.7, label: 'Vision × Integration' },
+    { a: 4, b: 5, weight: 0.6, label: 'Integration × Connection' },
+  ],
+  joint_operative_archetype: 'The Cauldron',
+  shared_keys: ['Jupiter MD coverage · Wheel of Fortune'],
+};
+
+describe('team-web SVG renderer (P5.2)', () => {
+  it('is registered in TOPOLOGY_RENDERERS as `web-graph`', () => {
+    assert.ok(TOPOLOGY_RENDERERS['web-graph']);
+    assert.equal(typeof TOPOLOGY_RENDERERS['web-graph'], 'function');
+  });
+
+  it('emits valid SVG string', () => {
+    const svg = renderTeamWeb(SIX_MEMBERS_DATA, { width: 880 });
+    assert.match(svg, /<svg xmlns/);
+    assert.match(svg, /<\/svg>/);
+  });
+
+  it('renders all members by name', () => {
+    const svg = renderTeamWeb(SIX_MEMBERS_DATA, { width: 880 });
+    for (const m of SIX_MEMBERS_DATA.members) {
+      assert.ok(svg.includes(m.name), `missing member: ${m.name}`);
+    }
+  });
+
+  it('emits cluster bounding hulls with data-cluster', () => {
+    const svg = renderTeamWeb(SIX_MEMBERS_DATA, { width: 880 });
+    assert.match(svg, /data-cluster="visionaries"/);
+    assert.match(svg, /data-cluster="operators"/);
+    assert.match(svg, /data-cluster="integrators"/);
+    assert.match(svg, /data-cluster="connectors"/);
+  });
+
+  it('emits cluster labels (DISPLAY casing)', () => {
+    const svg = renderTeamWeb(SIX_MEMBERS_DATA, { width: 880 });
+    assert.match(svg, /VISIONARIES/);
+    assert.match(svg, /OPERATORS/);
+    assert.match(svg, /INTEGRATORS/);
+    assert.match(svg, /CONNECTORS/);
+  });
+
+  it('emits critical-path edges with data-critical="true" + data-label', () => {
+    const svg = renderTeamWeb(SIX_MEMBERS_DATA, { width: 880 });
+    assert.match(svg, /data-critical="true"/);
+    assert.match(svg, /data-label="Vision × Ops handoff"/);
+  });
+
+  it('emits non-critical (background) edges with data-critical="false"', () => {
+    const svg = renderTeamWeb(SIX_MEMBERS_DATA, { width: 880 });
+    assert.match(svg, /data-critical="false"/);
+  });
+
+  it('emits joint-operative archetype label in center seed', () => {
+    const svg = renderTeamWeb(SIX_MEMBERS_DATA, { width: 880 });
+    assert.match(svg, /JOINT/);
+    assert.match(svg, /OPERATIVE/);
+    assert.match(svg, /THE CAULDRON/);
+  });
+
+  it('emits shared_keys legend at bottom when provided', () => {
+    const svg = renderTeamWeb(SIX_MEMBERS_DATA, { width: 880 });
+    assert.match(svg, /SHARED OPERATIONAL CURRENTS/);
+    assert.match(svg, /Jupiter MD coverage/);
+  });
+
+  it('renderByTopology dispatches web-graph correctly', () => {
+    const svg = renderByTopology('web-graph', SIX_MEMBERS_DATA, { width: 880 });
+    assert.match(svg, /<svg xmlns/);
+    assert.match(svg, /JOINT/);
+  });
+
+  it('throws on subject count below 2', () => {
+    const tooFew = { members: [{ name: 'X', role_cluster: 'visionaries' as const }], shared_keys: [] };
+    assert.throws(() => renderTeamWeb(tooFew, { width: 880 }), /requires 2-12 members/);
+  });
+
+  it('throws on subject count above 12', () => {
+    const tooMany = {
+      members: Array.from({ length: 13 }, (_, i) => ({ name: `M${i}`, role_cluster: 'visionaries' as const })),
+      shared_keys: [],
+    };
+    assert.throws(() => renderTeamWeb(tooMany, { width: 880 }), /requires 2-12 members/);
+  });
+
+  it('handles 12 members with all four clusters', () => {
+    const twelveMembers = {
+      members: Array.from({ length: 12 }, (_, i) => ({
+        name: `M${i}`,
+        role_cluster: (['visionaries', 'operators', 'integrators', 'connectors'] as const)[i % 4],
+      })),
+      shared_keys: [],
+    };
+    const svg = renderTeamWeb(twelveMembers, { width: 880 });
+    assert.match(svg, /<svg xmlns/);
+    // All 12 members should appear
+    for (let i = 0; i < 12; i++) {
+      assert.ok(svg.includes(`M${i}`));
+    }
+  });
+
+  it('handles a cluster with only 1 member (renders circle hull)', () => {
+    const singleClusterMember = {
+      members: [
+        { name: 'A', role_cluster: 'visionaries' as const },
+        { name: 'B', role_cluster: 'operators' as const },
+        { name: 'C', role_cluster: 'operators' as const },
+        { name: 'D', role_cluster: 'operators' as const },
+      ],
+      shared_keys: [],
+    };
+    const svg = renderTeamWeb(singleClusterMember, { width: 880 });
+    assert.match(svg, /<svg xmlns/);
+    // Visionaries cluster has 1 member; rendered as circle bounding hull
+    assert.match(svg, /data-cluster="visionaries"/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// Team-synergy interaction module (P5.3 #54)
+// ────────────────────────────────────────────────────────────────────────
+
+describe('team-synergy interaction module (P5.3)', () => {
+  it('is registered in MODE_INTERACTION_MODULES', () => {
+    assert.ok(MODE_INTERACTION_MODULES['team-synergy']);
+  });
+
+  it('CSS targets cluster filter buttons + dim states', () => {
+    const m = MODE_INTERACTION_MODULES['team-synergy'];
+    assert.match(m.scrollTimelineCss, /cluster-filter/);
+    assert.match(m.scrollTimelineCss, /data-cluster-filter/);
+  });
+
+  it('CSS targets critical-path edges with hover affordance', () => {
+    const m = MODE_INTERACTION_MODULES['team-synergy'];
+    assert.match(m.scrollTimelineCss, /data-critical="true"/);
+    assert.match(m.scrollTimelineCss, /cursor:\s*pointer/);
+  });
+
+  it('CSS includes dasha-cadence overlay with scroll-driven animation', () => {
+    const m = MODE_INTERACTION_MODULES['team-synergy'];
+    assert.match(m.scrollTimelineCss, /dasha-cadence-overlay/);
+    assert.match(m.scrollTimelineCss, /@supports.*animation-timeline/);
+  });
+
+  it('GSAP timeline reveals hulls before nodes before critical edges', () => {
+    const m = MODE_INTERACTION_MODULES['team-synergy'];
+    assert.match(m.gsapTimeline, /data-cluster/);
+    assert.match(m.gsapTimeline, /data-node/);
+    assert.match(m.gsapTimeline, /data-critical/);
+  });
+
+  it('event handlers implement cluster filter + edge tooltip + cadence toggle', () => {
+    const m = MODE_INTERACTION_MODULES['team-synergy'];
+    assert.match(m.eventHandlers, /cluster-filter button/);
+    assert.match(m.eventHandlers, /data-critical="true"/);
+    assert.match(m.eventHandlers, /cadence-on|data-cadence-on/);
+  });
+
+  it('buildInteractionPayload composes team-synergy on top of web-graph topology', () => {
+    const payload = buildInteractionPayload('web-graph', 'team-synergy');
+    assert.match(payload.css, /Team-Synergy mode interactions/);
+    assert.match(payload.handlers, /cluster-filter button/);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// renderInteractiveHTMLPage with team-synergy mode + web-graph topology
+// ────────────────────────────────────────────────────────────────────────
+
+describe('renderInteractiveHTMLPage — team-synergy wiring', () => {
+  const samplePart: PartBlock = {
+    partNum: 1, romanNumeral: 'I', title: 'Weave Map', contentHtml: '<p>x</p>',
+  };
+
+  it('emits data-mode="team-synergy" on .canvas.interactive', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'Team of 6', birth_date: '2026-01-01' },
+      topology: 'web-graph',
+      mode: 'team-synergy',
+      parts: [samplePart],
+    });
+    assert.match(html, /class="canvas interactive" data-mode="team-synergy"/);
+  });
+
+  it('inlines team-synergy interaction CSS + handlers', () => {
+    const html = renderInteractiveHTMLPage({
+      title: 'T',
+      cover: { subject: 'Team of 6', birth_date: '2026-01-01' },
+      topology: 'web-graph',
+      mode: 'team-synergy',
+      parts: [samplePart],
+    });
+    assert.match(html, /Team-Synergy mode interactions/);
+    assert.match(html, /cluster-filter/);
+  });
+});


### PR DESCRIPTION
## Summary
Phase 5 — the **first hierarchical-architecture reading mode** (outline + 3 expansion passes) and the **first variable-N mode** (4-12 subjects). Web-graph SVG topology uses deterministic cluster-arranged circular layout with convex bounding hulls — print-stable, no animation needed for positions.

**This is the last topology + mode pair.** All four svg_topology values are now real renderers. The substrate is complete.

## Closes
- Closes #52 — P5.1 team-synergy.md (hierarchical 1+3)
- Closes #53 — P5.2 team-web.ts (force-directed-style graph)
- Closes #54 — P5.3 Team-Synergy interaction module

## What changed

**Web-graph topology** (\`render/svg/team-web.ts\`, 392 LOC)
- Cluster-arranged circular layout: each role-cluster occupies a contiguous arc proportional to its size
- Convex-hull bounding shapes (Jarvis march) inflated 28px from centroid
- 4 cluster colors mapping to graha-signal: jupiter-gold (visionaries), saturn-slate (operators), coherence-emerald (integrators), venus-violet (connectors)
- All C(N,2) pair-edges; critical paths render as luminous gradient lines weighted 0.2-1.0; non-critical as faint background
- 4-12 member range enforced

**Team-synergy mode** (\`modes/team-synergy.md\`, hierarchical 4-pass, 12.5-15k word target)
- **OUTLINE pass** (1500w): produces structured weave map — role-cluster assignment, 3-5 critical-path partnerships (each crossing cluster boundaries), operational cadence (scale/consolidate/pivot quarters), joint-operative archetype, anchor codon ring
- **exp1** (4000w): Cluster Reading — per-cluster sub-section marked with \`section[data-cluster-section]\`
- **exp2** (4500w): Critical-Path Pair Threads — per-critical-path dyad mini-reading
- **exp3** (3500w): Joint Operative + Operational Cadence year-by-year + anti-dependency

**Mode interaction** (\`render/interactions/team-synergy.ts\`)
- Cluster filter (single-select, color-coded buttons) — dims non-matching nodes/edges/sections
- Critical-path edge hover → tooltip with partnership card
- Dasha-cadence overlay with \`animation-timeline: scroll()\` driven CSS fill

## Verification
- 136/136 tests pass (32 new + 104 prior, 3 updated for new functionality)
- team-synergy dry-run on 6-subject fixture passes
- All prior modes (5) still dry-run cleanly

## Test plan
- [ ] \`npm test\` → 136/136 pass
- [ ] Dry-run: \`integratedreading-mode.ts --mode team-synergy --subjects-dir <dir-with-4-12-cfgs> --output-dir <out> --dry-run\`
- [ ] Live run produces 12.5-15k word reading + web-graph SVG with role-clusters visible
- [ ] HTML artifact: cluster filter toggles work; hover critical-path edges shows tooltip

🤖 Generated with [Claude Code](https://claude.com/claude-code)