### PR TITLE
feat(consciousness-level): P1 contract freeze — resolver + schema + lexicons + API types

### DIFF
--- a/scripts/integratedreading/engine-lexicons-parser.ts
+++ b/scripts/integratedreading/engine-lexicons-parser.ts
@@ -1,0 +1,207 @@
+// ─── /integratedreading — Engine Lexicons Parser ──────────────────────
+// Reads engine-lexicons.md and returns per-engine + per-register vocab
+// and voice rules. The orchestrator injects the matching section into
+// the system prompt based on the request's resolved consciousness level.
+//
+// Per design doc 2026-05-15-consciousness-level-register-design.md § 1.3.
+// Closes #72 (P1.3 — schema + parser, content filled in #76 P2.3).
+
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import type { RegisterBand } from './modes/parser.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// Types
+// ────────────────────────────────────────────────────────────────────────
+
+/** Selemene engine IDs. Mirror what the Selemene API exposes. */
+export const KNOWN_ENGINE_IDS = [
+  'vimshottari',
+  'panchanga',
+  'ashtakavarga',
+  'vedic-clock',
+  'human-design',
+  'gene-keys',
+  'tarot',
+  'i-ching',
+  'numerology',
+  'biorhythm',
+  'nadabrahman',
+  'biofield',
+  'face-reading',
+  'sacred-geometry',
+  'enneagram',
+  'sigil-forge',
+] as const;
+
+export type EngineId = (typeof KNOWN_ENGINE_IDS)[number];
+
+export interface EngineLexicon {
+  vocab: string;        // raw markdown of the vocabulary block
+  voice_rules: string;  // raw markdown of the voice-rules block
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Path resolution
+// ────────────────────────────────────────────────────────────────────────
+
+/** Default location of engine-lexicons.md (next to the orchestrator). */
+function defaultLexiconsPath(): string {
+  return join(new URL('.', import.meta.url).pathname, 'engine-lexicons.md');
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Cache
+// ────────────────────────────────────────────────────────────────────────
+
+interface ParsedLexicons {
+  /** Map: engine_id → register → { vocab, voice_rules } */
+  engines: Record<string, Record<RegisterBand, EngineLexicon>>;
+}
+
+let _cache: { path: string; parsed: ParsedLexicons } | null = null;
+
+// ────────────────────────────────────────────────────────────────────────
+// Parser
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Parse the engine-lexicons.md file into a structured map.
+ *
+ * Section structure expected:
+ *   ## <engine-id>
+ *   ### L1-L3 register
+ *   **Vocabulary**
+ *   ... vocab markdown ...
+ *   **Voice rules**
+ *   ... voice rules ...
+ *   ### L4-L5 register
+ *   **Vocabulary**
+ *   ...
+ *
+ * Section delimiters tolerate the "L1-L3 register" and "L1-L3 Register"
+ * casing variants and any heading-trailing whitespace.
+ */
+export function parseLexicons(path?: string): ParsedLexicons {
+  const filePath = path ?? defaultLexiconsPath();
+  if (_cache && _cache.path === filePath) return _cache.parsed;
+
+  if (!existsSync(filePath)) {
+    throw new Error(`engine-lexicons.md not found at ${filePath}`);
+  }
+  const raw = readFileSync(filePath, 'utf-8');
+
+  const engines: Record<string, Record<RegisterBand, EngineLexicon>> = {};
+
+  // Split body by `## <name>` headers (level-2)
+  const engineSections = raw.split(/^## /m).slice(1);
+  for (const section of engineSections) {
+    const firstNewline = section.indexOf('\n');
+    if (firstNewline === -1) continue;
+    const heading = section.slice(0, firstNewline).trim().toLowerCase();
+    const body = section.slice(firstNewline + 1);
+
+    // Skip non-engine sections (e.g., "Lessons (autoresearch-appended)")
+    if (!(KNOWN_ENGINE_IDS as ReadonlyArray<string>).includes(heading)) continue;
+
+    const l1l3 = extractRegisterBlock(body, 'l1-l3');
+    const l4l5 = extractRegisterBlock(body, 'l4-l5');
+    engines[heading] = {
+      l1_l3: l1l3,
+      l4_l5: l4l5,
+    };
+  }
+
+  const parsed = { engines };
+  _cache = { path: filePath, parsed };
+  return parsed;
+}
+
+/**
+ * Extract the vocabulary + voice-rules sub-blocks for a register band
+ * from an engine's body. Returns empty strings if the band is absent.
+ */
+function extractRegisterBlock(
+  engineBody: string,
+  band: 'l1-l3' | 'l4-l5',
+): EngineLexicon {
+  // Match `### L1-L3 register` (case-insensitive, trailing whitespace OK)
+  const headingRe = new RegExp(`^### ${band} register\\s*$`, 'im');
+  const m = engineBody.match(headingRe);
+  if (!m || m.index === undefined) return { vocab: '', voice_rules: '' };
+
+  // Slice from heading to next ### or ## or end of body
+  const start = m.index + m[0].length;
+  const after = engineBody.slice(start);
+  const nextSectionRe = /^(### |## )/m;
+  const next = after.match(nextSectionRe);
+  const end = next && next.index !== undefined ? next.index : after.length;
+  const block = after.slice(0, end).trim();
+
+  // Extract **Vocabulary** ... **Voice rules** ... sub-blocks
+  const vocabMatch = block.match(/\*\*Vocabulary\*\*\s*\n([\s\S]*?)(?=\*\*Voice rules\*\*|$)/i);
+  const voiceMatch = block.match(/\*\*Voice rules\*\*\s*\n([\s\S]*?)$/i);
+
+  return {
+    vocab: vocabMatch ? vocabMatch[1].trim() : '',
+    voice_rules: voiceMatch ? voiceMatch[1].trim() : '',
+  };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Public API
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Look up the lexicon for a specific engine + register band.
+ *
+ * @throws when engine_id is not a recognized Selemene engine ID
+ */
+export function getEngineLexicon(
+  engine_id: string,
+  register: RegisterBand,
+  path?: string,
+): EngineLexicon {
+  if (!(KNOWN_ENGINE_IDS as ReadonlyArray<string>).includes(engine_id)) {
+    throw new Error(
+      `Unknown engine_id '${engine_id}'. Known: ${KNOWN_ENGINE_IDS.join(' | ')}`,
+    );
+  }
+  const parsed = parseLexicons(path);
+  const engine = parsed.engines[engine_id];
+  if (!engine) {
+    // Skeleton may legitimately not have content yet (P2.3 fills it)
+    return { vocab: '', voice_rules: '' };
+  }
+  return engine[register];
+}
+
+/**
+ * Compose a system-prompt-ready block from multiple engines at one register.
+ * Used by the orchestrator when injecting lexicons for the engines a mode
+ * foregrounds (per its engine_overlay_weights).
+ */
+export function composeLexiconBlock(
+  engine_ids: string[],
+  register: RegisterBand,
+  path?: string,
+): string {
+  const sections: string[] = [];
+  for (const id of engine_ids) {
+    const lex = getEngineLexicon(id, register, path);
+    if (!lex.vocab && !lex.voice_rules) continue;
+    sections.push(
+      `### ${id} (${register})\n` +
+      (lex.vocab ? `\n**Vocabulary**\n${lex.vocab}\n` : '') +
+      (lex.voice_rules ? `\n**Voice rules**\n${lex.voice_rules}\n` : ''),
+    );
+  }
+  if (sections.length === 0) return '';
+  return `## Engine Lexicons (${register})\n\n` + sections.join('\n');
+}
+
+/** Clear the in-memory cache. Useful for tests that swap fixture files. */
+export function clearLexiconCache(): void {
+  _cache = null;
+}

--- a/scripts/integratedreading/engine-lexicons.md
+++ b/scripts/integratedreading/engine-lexicons.md
@@ -1,0 +1,321 @@
+# Per-Engine Vocabulary Lexicons
+
+Single reference doc declaring the L1-L3 (traditional) vs L4-L5 (framework-native) vocabulary register and voice rules for each of the 16 Selemene engines. The orchestrator injects the matching engine's section into the system prompt based on the resolved consciousness level for the request.
+
+**Design source:** [docs/plans/2026-05-15-consciousness-level-register-design.md](../../docs/plans/2026-05-15-consciousness-level-register-design.md)
+**Schema deliverable:** P1.3 (#72) — this skeleton only
+**Content deliverable:** P2.3 (#76) — populates all 16 sections
+
+---
+
+## File contract
+
+- One `## <engine-id>` section per Selemene engine. Engine ids are kebab-case + match the Selemene API's engine identifier
+- Each section has two sub-sections:
+  - `### L1-L3 register` — traditional vocabulary table + voice rules
+  - `### L4-L5 register` — framework-native vocabulary table + voice rules
+- Each register sub-section has two parts:
+  - **Vocabulary** — a markdown table of the terms this register uses + brief gloss
+  - **Voice rules** — short bullet list of what the LLM is allowed/required/forbidden when using this register
+
+**Parser API** (see [`engine-lexicons-parser.ts`](engine-lexicons-parser.ts)):
+```ts
+getEngineLexicon(engine_id: string, register: 'l1_l3' | 'l4_l5'):
+  { vocab: string; voice_rules: string }
+```
+
+Throws on unknown engine_id. Returns the raw markdown of each sub-block.
+
+---
+
+## vimshottari
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — populated in P2.3 #76. Will name: Mahadasha · Antardasha · Pratyantar · Lord-of-the-period · sign-house-nakshatra of dasha lord · timing in years/months · benefic/malefic dasha sequence.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — populated in P2.3. Will name: phase-lock geometry · dasha-cadence overlap matrix · pivot-stagger as structural data · Cl(3) Vijnanamaya wisdom-layer temporal signature.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## panchanga
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Tithi · Vara · Nakshatra · Yoga · Karana · auspicious vs inauspicious time · Hora · Choghadiya.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — day-of-pivot Mitwelt ratification signal · five-limb almanac as Cl(2) pattern grammar.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## ashtakavarga
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Bindu count by house and planet · Sarvashtakavarga · Bhinnashtakavarga · 30-point benchmark · transit-Ashtakavarga.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — engine-weighted bhuta signature · cross-engine cumulative resonance.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## vedic-clock
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Hora-based hour-by-hour planetary signal · Kalachakra · time-of-day auspiciousness.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — Cl(3) Vijnanamaya wisdom-layer temporal signature · time-cone structuring.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## human-design
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Type (Generator/Projector/Manifestor/Reflector/MG) · Strategy · Authority · Centers (9) · Channels · Profile · Incarnation Cross.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — electromagnetic channels · Pranamaya (vital) layer routing · Cl(1) breath signature · cross-coupling channel-completion as field-current.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## gene-keys
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Shadow / Gift / Siddhi triad · Activation / Evolution / Radiance / Purpose spheres · Pearl · Hologenetic Profile · Codon Ring.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — codon ring of the field · Manomaya (pattern engine) Cl(2) signature · sphere-of-purpose coupling.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## tarot
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Major Arcana · Court cards · Minor Arcana suits · traditional spreads · upright vs reversed.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — Mitwelt-archetypal current · Cl(7) Anandamaya imperishable seed · joint Major Arcana stack as cultural-current vector.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## i-ching
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Hexagram name + number · changing lines · Sequence of King Wen · Image · Judgment · Trigrams.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — compositional state-vector · 64-state semantic phase-space.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## numerology
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Life Path · Expression · Soul Urge · Personality (Pythagorean) · Master Numbers · Day Number · Year Number.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — numeric-seed bhuta resonance · digit-root cycle as Cl(2) compression signal.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## biorhythm
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Physical · Emotional · Intellectual sine waves · cycle days · critical days · peak vs trough.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — Pranic phase-lock cadence · Cl(1) Pranamaya wave-superposition signature.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## nadabrahman
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — sound-syllable resonance · Ayurvedic body type (Vata/Pitta/Kapha) · personal mantra · bija syllable.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — Cl(1) Pranamaya audio-signature · syllabic resonance as breath-current.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## biofield
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Aura layers · Chakras (7) · subtle body · prana flow · energetic blockages.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — Annamaya (body) measurable substrate · Multiscan-PRO / biophoton imaging signal · Cl(0) somatic phase-state.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## face-reading
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Mian Xiang traditional 5-feature reading · forehead/eyes/nose/mouth/chin signs · facial mole + scar interpretation.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — Cl(0) Annamaya morphological signal · facial-feature constellation as embodied signature.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## sacred-geometry
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Yantras · personal mandala · Sri Yantra · Flower of Life · Metatron's Cube · sacred ratios.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — Anandamaya Cl(7) imperishable form-current · generative grammar of mandalic compression.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## enneagram
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Type 1-9 · wings · arrows of integration/disintegration · triads (Gut/Heart/Head) · instincts (SP/SO/SX).)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — pattern-engine bias map · Manomaya Cl(2) attentional-vector signature.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## sigil-forge
+
+### L1-L3 register
+**Vocabulary**
+*(TBD — Personal sigil · intention-encoded glyph · ritual activation · talismanic geometry.)*
+
+**Voice rules**
+- *(TBD)*
+
+### L4-L5 register
+**Vocabulary**
+*(TBD — AKSHARA-seed materialization tool · Cl(7) imperishable-seed externalization.)*
+
+**Voice rules**
+- *(TBD)*
+
+---
+
+## Lessons (autoresearch-appended)
+
+*(No autoresearch lessons yet. Per-engine lexicon refinements will be appended date-stamped per autoresearch contract.)*

--- a/scripts/integratedreading/level-resolver.ts
+++ b/scripts/integratedreading/level-resolver.ts
@@ -1,0 +1,169 @@
+// ─── /integratedreading — Consciousness-Level Resolver ────────────────
+// Single source of truth for resolving a request's effective
+// consciousness_level (1-5).
+//
+// Resolution precedence:
+//   1. admin_payload_override  — only honored when caller is admin/initiate
+//   2. user_db_stored_level    — looked up via the caller-supplied lookup fn
+//   3. default_level           — falls back to 1 (uninitiated)
+//
+// SECURITY BOUNDARY
+// ─────────────────
+// The admin_override path requires explicit authentication of the caller.
+// A non-admin user passing `admin_override: 5` in their request MUST be
+// rejected — otherwise any end-user could escalate to the framework-native
+// reading register simply by editing their HTTP request body.
+//
+// Per design doc 2026-05-15-consciousness-level-register-design.md.
+// Closes #70 (P1.1).
+
+// ────────────────────────────────────────────────────────────────────────
+// Types
+// ────────────────────────────────────────────────────────────────────────
+
+export type ConsciousnessLevel = 1 | 2 | 3 | 4 | 5;
+
+export type RegisterBand = 'l1_l3' | 'l4_l5';
+
+export type LevelSource = 'admin_override' | 'user_db' | 'default';
+
+export type Tier = 'free' | 'subscriber' | 'enterprise' | 'initiate';
+
+export interface ResolveLevelInput {
+  /** The end-user this reading is for. Used to look up their stored level. */
+  user_id: string;
+  /**
+   * Admin-supplied level override (1-5). Only honored when the caller
+   * (NOT the user) is authenticated as admin or initiate tier.
+   */
+  admin_override?: number;
+  /** The CALLER's tier (the entity making the API request, not necessarily the user). */
+  caller_tier?: Tier;
+  /** Explicit admin role flag — alternative to initiate tier. */
+  caller_is_admin?: boolean;
+  /** Default when user is not found / first-time. Conventionally 1. */
+  default_level?: number;
+  /**
+   * Looks up the target user's stored consciousness_level from the DB.
+   * Caller injects this so the resolver stays pure + testable.
+   * Returns undefined when user not found.
+   */
+  user_db_lookup?: (user_id: string) => number | undefined;
+}
+
+export interface ResolveLevelResult {
+  effective_level: ConsciousnessLevel;
+  source: LevelSource;
+  /** Derived from effective_level: 1-3 = l1_l3, 4-5 = l4_l5. */
+  register_band: RegisterBand;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Error types
+// ────────────────────────────────────────────────────────────────────────
+
+export class ForbiddenLevelOverrideError extends Error {
+  /** Maps to HTTP 403 in API layer. */
+  public readonly status: number = 403;
+  public readonly code: string = 'FORBIDDEN_LEVEL_OVERRIDE';
+  constructor(message: string) {
+    super(message);
+    this.name = 'ForbiddenLevelOverrideError';
+  }
+}
+
+export class InvalidConsciousnessLevelError extends Error {
+  public readonly status: number = 400;
+  public readonly code: string = 'INVALID_CONSCIOUSNESS_LEVEL';
+  constructor(message: string) {
+    super(message);
+    this.name = 'InvalidConsciousnessLevelError';
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Validation
+// ────────────────────────────────────────────────────────────────────────
+
+function isValidLevel(n: unknown): n is ConsciousnessLevel {
+  return typeof n === 'number' && Number.isInteger(n) && n >= 1 && n <= 5;
+}
+
+/**
+ * Whether the caller is authorized to override the user's stored level
+ * via the admin_override path. Either `initiate` tier OR explicit admin flag.
+ */
+export function isCallerAdmin(input: Pick<ResolveLevelInput, 'caller_tier' | 'caller_is_admin'>): boolean {
+  if (input.caller_is_admin === true) return true;
+  if (input.caller_tier === 'initiate') return true;
+  return false;
+}
+
+/** Map a 1-5 level to its register band. */
+export function levelToRegisterBand(level: ConsciousnessLevel): RegisterBand {
+  return level >= 4 ? 'l4_l5' : 'l1_l3';
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Resolver
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolves the effective consciousness_level for a reading request.
+ *
+ * @throws {ForbiddenLevelOverrideError} when admin_override is set but
+ *         caller is not admin/initiate
+ * @throws {InvalidConsciousnessLevelError} when any level value is not
+ *         an integer in [1, 5]
+ */
+export function resolveLevel(input: ResolveLevelInput): ResolveLevelResult {
+  const defaultLevel = input.default_level ?? 1;
+  if (!isValidLevel(defaultLevel)) {
+    throw new InvalidConsciousnessLevelError(
+      `default_level must be an integer 1-5, got ${defaultLevel}`,
+    );
+  }
+
+  // 1. Admin override path
+  if (input.admin_override !== undefined && input.admin_override !== null) {
+    if (!isValidLevel(input.admin_override)) {
+      throw new InvalidConsciousnessLevelError(
+        `admin_override must be an integer 1-5, got ${input.admin_override}`,
+      );
+    }
+    if (!isCallerAdmin(input)) {
+      throw new ForbiddenLevelOverrideError(
+        `consciousness_level override (${input.admin_override}) requires admin role or initiate tier; caller_tier='${input.caller_tier ?? 'unknown'}', caller_is_admin=${input.caller_is_admin ?? false}`,
+      );
+    }
+    return {
+      effective_level: input.admin_override,
+      source: 'admin_override',
+      register_band: levelToRegisterBand(input.admin_override),
+    };
+  }
+
+  // 2. User DB lookup
+  if (input.user_db_lookup) {
+    const stored = input.user_db_lookup(input.user_id);
+    if (stored !== undefined && stored !== null) {
+      if (!isValidLevel(stored)) {
+        throw new InvalidConsciousnessLevelError(
+          `user_db_lookup returned invalid level ${stored} for user ${input.user_id}`,
+        );
+      }
+      return {
+        effective_level: stored,
+        source: 'user_db',
+        register_band: levelToRegisterBand(stored),
+      };
+    }
+  }
+
+  // 3. Default
+  return {
+    effective_level: defaultLevel as ConsciousnessLevel,
+    source: 'default',
+    register_band: levelToRegisterBand(defaultLevel as ConsciousnessLevel),
+  };
+}

--- a/scripts/integratedreading/modes/_schema.md
+++ b/scripts/integratedreading/modes/_schema.md
@@ -62,6 +62,28 @@ house_overlay: [7, 11, 12, 5, 2]         # Vedic houses to foreground
 bridge_mandates:                         # mode-specific four-way triangulation rules
   - "Every major claim must braid: Vedic-7th × Tarot-relational × HD-electromagnetic-channel × dasha-anchor"
 svg_topology: dyad-arc                   # one of: dyad-arc | triad-triangle | pentagon | web-graph
+
+# ── Consciousness-level register variants (OPTIONAL, hardened 2026-05-15) ──
+# When present, the orchestrator uses the resolved level's register band
+# ('l1_l3' for levels 1-3 / 'l4_l5' for levels 4-5) to pick per-pass
+# template overrides. Mode docs without this block keep current L5 behavior.
+register_variants:
+  l1_l3:                                 # traditional vocabulary register
+    target_words:
+      min: 9000
+      max: 11000
+    overrides:
+      - pass_id: alpha
+        template: pass-alpha-template-l1-l3   # named section in this same doc
+      - pass_id: beta
+        template: pass-beta-template-l1-l3
+  l4_l5:                                 # framework-native register
+    target_words:
+      min: 12000
+      max: 15000
+    overrides:                           # passes not listed fall back to pass_plan default
+      - pass_id: alpha
+        template: pass-alpha-template
 ---
 ```
 
@@ -79,6 +101,20 @@ svg_topology: dyad-arc                   # one of: dyad-arc | triad-triangle | p
 | `house_overlay` | `number[]` | Vedic house numbers (1-12). |
 | `bridge_mandates` | `string[]` | Mode-specific 4-way triangulation rules. Folded into every pass system prompt. |
 | `svg_topology` | `TopologyKey` | One of `dyad-arc` / `triad-triangle` / `pentagon` / `web-graph`. Routes to the matching renderer in `render/svg/index.ts`. |
+| `register_variants` | `RegisterVariants` (optional) | Consciousness-level register branching. See "Register variants" section below. |
+
+### Register variants
+
+Optional. Mode docs declare alternative pass templates and target word ranges for each register band:
+
+- **`l1_l3`** — traditional vocabulary, used for users at consciousness_level 1, 2, or 3. Vedic Kundali conventions (Lagna, Rashi, Nakshatra, dasha, yogas, doshas, remedies). 11-Part baseline structure. ~9-11k words.
+- **`l4_l5`** — framework-native vocabulary, used for users at level 4 or 5. Aletheios/Pichet dyad, Kosha-Clifford layering, Eigenwelt/Mitwelt/Umwelt, AKSHARA seed, anti-dependency telos. ~12-15k words.
+
+Each variant declares optional `target_words` (falls back to the mode's canonical range) and `overrides` (per-pass template substitutions). Passes not listed in `overrides` use the canonical `pass_plan` template.
+
+**Backward compatibility:** Mode docs without `register_variants` retain current L5 behavior. The orchestrator falls back to canonical templates.
+
+**Body sections for variants:** Per-band template overrides MUST resolve to `## section-name` body sections in the same mode doc (e.g., `pass-alpha-template-l1-l3`). The parser validates this at parse time.
 
 ### Pass spec fields
 

--- a/scripts/integratedreading/modes/parser.ts
+++ b/scripts/integratedreading/modes/parser.ts
@@ -27,6 +27,34 @@ export interface PassSpec {
   model?: string;            // optional NVIDIA model override; falls back to SYNTH_MODELS.PRIMARY
 }
 
+// ── Consciousness-level register-variant schema (P1.2 #71) ─────────────
+// Optional. When present, the orchestrator uses the resolved level's
+// register band ('l1_l3' | 'l4_l5') to pick per-pass template overrides.
+// Mode docs without `register_variants` retain current L5 behavior
+// (backward-compat).
+
+export type RegisterBand = 'l1_l3' | 'l4_l5';
+
+export interface PassTemplateOverride {
+  pass_id: string;            // matches PassSpec.id
+  template: string;           // section anchor in this same mode doc
+}
+
+export interface RegisterVariantSpec {
+  /** Target word range for this register band — typically tighter for
+   *  L1-L3 (~9-11k) and wider for L4-L5 (~12-15k). */
+  target_words?: { min: number; max: number };
+  /** Per-pass template overrides. Each pass_id MUST exist in pass_plan;
+   *  the named template MUST resolve to a body section. Passes not
+   *  listed fall back to their pass_plan default template. */
+  overrides?: PassTemplateOverride[];
+}
+
+export interface RegisterVariants {
+  l1_l3?: RegisterVariantSpec;
+  l4_l5?: RegisterVariantSpec;
+}
+
 export interface ModeConfig {
   mode: string;
   subject_count: { min: number; max: number };
@@ -38,6 +66,8 @@ export interface ModeConfig {
   house_overlay: number[];
   bridge_mandates: string[];
   svg_topology: TopologyKey;
+  /** Optional. Absence = current L5 behavior (backward-compat). */
+  register_variants?: RegisterVariants;
 }
 
 export interface LessonsEntry {
@@ -259,6 +289,9 @@ export function parseModeDoc(path: string): ParsedModeDoc {
     }
   }
 
+  // register_variants (P1.2 #71) — validate any overrides
+  validateRegisterVariants(frontmatter, sections, path);
+
   return {
     frontmatter,
     sections,
@@ -277,3 +310,87 @@ export function summarizeLessons(lessons: LessonsEntry[], maxEntries = 5): strin
   });
   return `## Prior Autoresearch Findings\n\n${lines.join('\n')}`;
 }
+
+// ────────────────────────────────────────────────────────────────────────
+// Register-variant resolution (P1.2 #71)
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve which body-section template to use for a given pass + register band.
+ *
+ * Resolution order:
+ *   1. If `register_variants[band].overrides` lists this pass_id, use that template
+ *   2. Otherwise fall back to the canonical pass_plan entry's `template`
+ *
+ * Returns the section content (raw markdown). Throws if the resolved
+ * template doesn't exist in the parsed sections map.
+ */
+export function getPassTemplate(
+  doc: ParsedModeDoc,
+  pass_id: string,
+  register: RegisterBand,
+): string {
+  const pass = doc.frontmatter.pass_plan.find((p) => p.id === pass_id);
+  if (!pass) {
+    throw new Error(`No pass with id '${pass_id}' in mode '${doc.frontmatter.mode}'`);
+  }
+
+  // Check for register-variant override first
+  const variant = doc.frontmatter.register_variants?.[register];
+  const override = variant?.overrides?.find((o) => o.pass_id === pass_id);
+  const templateName = override?.template ?? pass.template;
+
+  const content = doc.sections[templateName];
+  if (content === undefined) {
+    throw new Error(
+      `Pass '${pass_id}' (register ${register}) resolves to template '${templateName}' which has no matching '## ${templateName}' section in mode '${doc.frontmatter.mode}'`,
+    );
+  }
+  return content;
+}
+
+/**
+ * Get the resolved target_words range for a register band.
+ * Falls back to the canonical frontmatter `target_words` if the band
+ * doesn't declare its own.
+ */
+export function getTargetWordsForRegister(
+  doc: ParsedModeDoc,
+  register: RegisterBand,
+): { min: number; max: number } {
+  const variant = doc.frontmatter.register_variants?.[register];
+  return variant?.target_words ?? doc.frontmatter.target_words;
+}
+
+/**
+ * Validate that every override in register_variants points to a real
+ * pass_id + real body section. Called inside parseModeDoc when
+ * register_variants is present.
+ */
+function validateRegisterVariants(
+  fm: ModeConfig,
+  sections: Record<string, string>,
+  path: string,
+): void {
+  if (!fm.register_variants) return;
+  for (const band of ['l1_l3', 'l4_l5'] as RegisterBand[]) {
+    const variant = fm.register_variants[band];
+    if (!variant?.overrides) continue;
+    for (const ov of variant.overrides) {
+      const pass = fm.pass_plan.find((p) => p.id === ov.pass_id);
+      if (!pass) {
+        throw new Error(
+          `Mode doc ${path}: register_variants.${band}.overrides[].pass_id '${ov.pass_id}' has no matching pass in pass_plan`,
+        );
+      }
+      if (!sections[ov.template]) {
+        throw new Error(
+          `Mode doc ${path}: register_variants.${band}.overrides for pass '${ov.pass_id}' references template '${ov.template}' which has no '## ${ov.template}' section`,
+        );
+      }
+    }
+  }
+}
+
+// Re-export the validator for tests
+export { validateRegisterVariants };

--- a/src/types/reading-request.ts
+++ b/src/types/reading-request.ts
@@ -1,0 +1,143 @@
+// ─── Reading Request / Response Contract ──────────────────────────────
+// API contract for the integratedreading pipeline. Defines the request
+// payload shape (including the new consciousness_level admin override)
+// and the response shape (including the resolved level + source for
+// auditability).
+//
+// Per design doc 2026-05-15-consciousness-level-register-design.md § 1.4.
+// Closes #73 (P1.4).
+
+import type { Tier } from './interpretation.js';
+import type {
+  ConsciousnessLevel,
+  LevelSource,
+  RegisterBand,
+} from '../../scripts/integratedreading/level-resolver.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// Re-exports — single import surface for consumers
+// ────────────────────────────────────────────────────────────────────────
+
+export type {
+  ConsciousnessLevel,
+  LevelSource,
+  RegisterBand,
+  Tier,
+};
+
+// ────────────────────────────────────────────────────────────────────────
+// Subject reference shape used in request payloads
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * Lightweight subject reference. Either a stored profile_id (the server
+ * looks up the full birth-data record) OR an inline birth-data payload
+ * for one-shot anonymous readings.
+ */
+export type SubjectRef =
+  | { profile_id: string }
+  | {
+      subject: string;
+      birth_date: string;        // YYYY-MM-DD
+      birth_time?: string;       // HH:MM[:SS]
+      birth_place?: string;
+      latitude?: number;
+      longitude?: number;
+      timezone?: string;
+    };
+
+// ────────────────────────────────────────────────────────────────────────
+// Request shape — what callers POST to the reading endpoints
+// ────────────────────────────────────────────────────────────────────────
+
+export interface ReadingRequest {
+  /** The end-user the reading is FOR (used for stored-level lookup). */
+  user_id: string;
+  /** Mode key: 'composite-dyad' | 'partner-synastry' | etc. */
+  mode: string;
+  /** Subjects in ordinal order — matches mode's role slots. */
+  subjects: SubjectRef[];
+  /**
+   * Optional admin override. Only honored when the calling identity
+   * (server-side, NOT this payload) has `tier === 'initiate'` OR an
+   * explicit admin role flag. Non-admin requests passing this field
+   * receive a 403 ForbiddenLevelOverride.
+   *
+   * Use case: admin generating QA / preview readings at a higher
+   * register without changing the user's stored level permanently.
+   */
+  consciousness_level?: ConsciousnessLevel;
+  /** Optional flag to chain solo synthesis for missing subjects. */
+  chain_solos?: boolean;
+  /** Optional flag to reuse the most-recent cached run if present. */
+  use_cache?: boolean;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Response shape — what the reading endpoints return
+// ────────────────────────────────────────────────────────────────────────
+
+export interface ReadingResponse {
+  reading_id: string;
+  /** The level the orchestrator actually used (1-5). Always present. */
+  effective_consciousness_level: ConsciousnessLevel;
+  /** How the level was resolved — useful for client-side auditability + debug. */
+  level_source: LevelSource;
+  /** Which register band the reading was generated in. */
+  register_band: RegisterBand;
+  /** Mode key the reading was generated for. */
+  mode: string;
+  /** Total assembled word count. */
+  total_words: number;
+  /** Per-pass metric summary. */
+  pass_metrics: Array<{
+    id: string;
+    title: string;
+    words: number;
+    xrefs: number;
+    target_words: number;
+    latency_ms: number;
+    model: string;
+  }>;
+  /** Path to assembled markdown file (when applicable for server-rendered outputs). */
+  markdown_path?: string;
+  /** Path to interactive HTML artifact. */
+  html_path?: string;
+  /** Path to standalone SVG. */
+  svg_path?: string;
+  /** Run timestamp (ISO 8601). */
+  generated_at: string;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Error response shape
+// ────────────────────────────────────────────────────────────────────────
+
+export interface ReadingErrorResponse {
+  error: string;
+  code:
+    | 'FORBIDDEN_LEVEL_OVERRIDE'
+    | 'INVALID_CONSCIOUSNESS_LEVEL'
+    | 'UNKNOWN_MODE'
+    | 'SUBJECT_COUNT_MISMATCH'
+    | 'MISSING_SOLO_SYNTHESIS'
+    | 'INTERNAL_ERROR';
+  /** Caller-visible details — never leaks internal stack traces. */
+  details?: Record<string, unknown>;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Caller-identity shape — server passes this to the level-resolver
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * The authenticated caller's identity. Populated by the server's auth
+ * middleware after verifying JWT / API key / etc. The orchestrator
+ * receives this as INPUT — it never derives it from the request payload
+ * (which would be trivially spoofable).
+ */
+export interface CallerIdentity {
+  caller_id: string;
+  caller_tier: Tier;
+  caller_is_admin: boolean;
+}

--- a/tests/consciousness-level-contracts.test.ts
+++ b/tests/consciousness-level-contracts.test.ts
@@ -1,0 +1,633 @@
+// ─── P1 — Consciousness-Level Contract Tests ──────────────────────────
+// Covers all 4 Phase 1 contracts for the consciousness-level register
+// system: level-resolver (1.1), mode-doc register-variant schema (1.2),
+// engine-lexicons schema (1.3), API request/response types (1.4).
+//
+// Closes #70, #71, #72, #73 (verification half).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import {
+  resolveLevel,
+  isCallerAdmin,
+  levelToRegisterBand,
+  ForbiddenLevelOverrideError,
+  InvalidConsciousnessLevelError,
+  type ConsciousnessLevel,
+} from '../scripts/integratedreading/level-resolver.js';
+import {
+  parseModeDoc,
+  getPassTemplate,
+  getTargetWordsForRegister,
+} from '../scripts/integratedreading/modes/parser.js';
+import {
+  getEngineLexicon,
+  composeLexiconBlock,
+  parseLexicons,
+  clearLexiconCache,
+  KNOWN_ENGINE_IDS,
+} from '../scripts/integratedreading/engine-lexicons-parser.js';
+import type {
+  ReadingRequest,
+  ReadingResponse,
+  CallerIdentity,
+} from '../src/types/reading-request.js';
+
+// ════════════════════════════════════════════════════════════════════════
+// P1.1 — Level resolver (#70)
+// ════════════════════════════════════════════════════════════════════════
+
+describe('P1.1 — resolveLevel', () => {
+  it('admin caller (initiate tier) with admin_override → returns the override', () => {
+    const r = resolveLevel({
+      user_id: 'user-1',
+      admin_override: 3,
+      caller_tier: 'initiate',
+    });
+    assert.equal(r.effective_level, 3);
+    assert.equal(r.source, 'admin_override');
+    assert.equal(r.register_band, 'l1_l3');
+  });
+
+  it('admin caller (caller_is_admin) with admin_override → returns the override', () => {
+    const r = resolveLevel({
+      user_id: 'user-1',
+      admin_override: 5,
+      caller_tier: 'free',
+      caller_is_admin: true,
+    });
+    assert.equal(r.effective_level, 5);
+    assert.equal(r.source, 'admin_override');
+    assert.equal(r.register_band, 'l4_l5');
+  });
+
+  it('non-admin caller with admin_override → throws ForbiddenLevelOverrideError', () => {
+    assert.throws(
+      () => resolveLevel({
+        user_id: 'user-1',
+        admin_override: 5,
+        caller_tier: 'subscriber',
+      }),
+      (err: any) => {
+        return err instanceof ForbiddenLevelOverrideError && err.status === 403;
+      },
+    );
+  });
+
+  it('non-admin caller with admin_override (free tier) → throws', () => {
+    assert.throws(
+      () => resolveLevel({
+        user_id: 'user-1',
+        admin_override: 3,
+        caller_tier: 'free',
+        caller_is_admin: false,
+      }),
+      ForbiddenLevelOverrideError,
+    );
+  });
+
+  it('normal user (no override, no admin) → resolves via user_db_lookup', () => {
+    const r = resolveLevel({
+      user_id: 'user-1',
+      user_db_lookup: (id) => (id === 'user-1' ? 2 : undefined),
+    });
+    assert.equal(r.effective_level, 2);
+    assert.equal(r.source, 'user_db');
+    assert.equal(r.register_band, 'l1_l3');
+  });
+
+  it('user not in DB → falls back to default level (1)', () => {
+    const r = resolveLevel({
+      user_id: 'unknown',
+      user_db_lookup: () => undefined,
+    });
+    assert.equal(r.effective_level, 1);
+    assert.equal(r.source, 'default');
+    assert.equal(r.register_band, 'l1_l3');
+  });
+
+  it('user not in DB, custom default_level → uses that default', () => {
+    const r = resolveLevel({
+      user_id: 'unknown',
+      default_level: 4,
+    });
+    assert.equal(r.effective_level, 4);
+    assert.equal(r.source, 'default');
+    assert.equal(r.register_band, 'l4_l5');
+  });
+
+  it('invalid admin_override (0) → throws InvalidConsciousnessLevelError', () => {
+    assert.throws(
+      () => resolveLevel({
+        user_id: 'u',
+        admin_override: 0,
+        caller_tier: 'initiate',
+      }),
+      InvalidConsciousnessLevelError,
+    );
+  });
+
+  it('invalid admin_override (6) → throws', () => {
+    assert.throws(
+      () => resolveLevel({
+        user_id: 'u',
+        admin_override: 6,
+        caller_tier: 'initiate',
+      }),
+      InvalidConsciousnessLevelError,
+    );
+  });
+
+  it('invalid admin_override (string) → throws', () => {
+    assert.throws(
+      () => resolveLevel({
+        user_id: 'u',
+        admin_override: '3' as any,
+        caller_tier: 'initiate',
+      }),
+      InvalidConsciousnessLevelError,
+    );
+  });
+
+  it('user_db_lookup returns invalid level → throws', () => {
+    assert.throws(
+      () => resolveLevel({
+        user_id: 'u',
+        user_db_lookup: () => 99,
+      }),
+      InvalidConsciousnessLevelError,
+    );
+  });
+
+  it('invalid default_level → throws', () => {
+    assert.throws(
+      () => resolveLevel({
+        user_id: 'u',
+        default_level: 0,
+      }),
+      InvalidConsciousnessLevelError,
+    );
+  });
+
+  it('admin_override: null is treated as "not set" (falls back to lookup)', () => {
+    const r = resolveLevel({
+      user_id: 'u',
+      admin_override: null as any,
+      user_db_lookup: () => 4,
+    });
+    assert.equal(r.source, 'user_db');
+    assert.equal(r.effective_level, 4);
+  });
+});
+
+describe('P1.1 — isCallerAdmin helper', () => {
+  it('initiate tier → true', () => {
+    assert.equal(isCallerAdmin({ caller_tier: 'initiate' }), true);
+  });
+  it('caller_is_admin flag → true', () => {
+    assert.equal(isCallerAdmin({ caller_tier: 'free', caller_is_admin: true }), true);
+  });
+  it('subscriber/enterprise → false', () => {
+    assert.equal(isCallerAdmin({ caller_tier: 'subscriber' }), false);
+    assert.equal(isCallerAdmin({ caller_tier: 'enterprise' }), false);
+  });
+  it('no tier, no admin flag → false', () => {
+    assert.equal(isCallerAdmin({}), false);
+  });
+});
+
+describe('P1.1 — levelToRegisterBand', () => {
+  it('1, 2, 3 → l1_l3', () => {
+    assert.equal(levelToRegisterBand(1), 'l1_l3');
+    assert.equal(levelToRegisterBand(2), 'l1_l3');
+    assert.equal(levelToRegisterBand(3), 'l1_l3');
+  });
+  it('4, 5 → l4_l5', () => {
+    assert.equal(levelToRegisterBand(4), 'l4_l5');
+    assert.equal(levelToRegisterBand(5), 'l4_l5');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// P1.2 — Mode-doc register-variant schema (#71)
+// ════════════════════════════════════════════════════════════════════════
+
+function makeTempDoc(content: string): { path: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), 'mode-doc-register-test-'));
+  const path = join(dir, 'sample.md');
+  writeFileSync(path, content, 'utf-8');
+  return { path, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+const DOC_WITH_VARIANTS = `---
+mode: test-mode
+subject_count: { min: 2, max: 2 }
+roles: [a, b]
+target_words: { min: 12000, max: 15000 }
+architecture: linear
+pass_plan:
+  - id: alpha
+    title: Alpha
+    target_words: 6000
+    template: pass-alpha-template
+  - id: beta
+    title: Beta
+    target_words: 6000
+    template: pass-beta-template
+engine_overlay_weights:
+  tarot: 2.0
+house_overlay: [7]
+bridge_mandates:
+  - mandate-x
+svg_topology: dyad-arc
+register_variants:
+  l1_l3:
+    target_words:
+      min: 9000
+      max: 11000
+    overrides:
+      - pass_id: alpha
+        template: pass-alpha-template-l1-l3
+  l4_l5:
+    target_words:
+      min: 12000
+      max: 15000
+---
+
+## pass-alpha-template
+
+L5 alpha template body.
+
+## pass-alpha-template-l1-l3
+
+L1-L3 alpha template body.
+
+## pass-beta-template
+
+Beta template body.
+`;
+
+const DOC_WITHOUT_VARIANTS = `---
+mode: legacy-mode
+subject_count: { min: 2, max: 2 }
+roles: [a, b]
+target_words: { min: 12000, max: 15000 }
+architecture: linear
+pass_plan:
+  - id: alpha
+    title: Alpha
+    target_words: 6000
+    template: pass-alpha-template
+engine_overlay_weights: { tarot: 1.0 }
+house_overlay: [7]
+bridge_mandates: [mandate]
+svg_topology: dyad-arc
+---
+
+## pass-alpha-template
+
+legacy body
+`;
+
+describe('P1.2 — register_variants parsing', () => {
+  it('parses register_variants block when present', () => {
+    const { path, cleanup } = makeTempDoc(DOC_WITH_VARIANTS);
+    try {
+      const doc = parseModeDoc(path);
+      assert.ok(doc.frontmatter.register_variants);
+      assert.equal(doc.frontmatter.register_variants?.l1_l3?.target_words?.min, 9000);
+      assert.equal(doc.frontmatter.register_variants?.l1_l3?.overrides?.length, 1);
+      assert.equal(doc.frontmatter.register_variants?.l1_l3?.overrides?.[0].pass_id, 'alpha');
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('mode doc WITHOUT register_variants parses cleanly (backward-compat)', () => {
+    const { path, cleanup } = makeTempDoc(DOC_WITHOUT_VARIANTS);
+    try {
+      const doc = parseModeDoc(path);
+      assert.equal(doc.frontmatter.register_variants, undefined);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('throws when register_variants override pass_id not in pass_plan', () => {
+    const bad = DOC_WITH_VARIANTS.replace('pass_id: alpha', 'pass_id: nonexistent');
+    const { path, cleanup } = makeTempDoc(bad);
+    try {
+      assert.throws(() => parseModeDoc(path), /pass_id 'nonexistent' has no matching pass/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('throws when register_variants override template has no body section', () => {
+    const bad = DOC_WITH_VARIANTS.replace(
+      'template: pass-alpha-template-l1-l3',
+      'template: nonexistent-template',
+    );
+    const { path, cleanup } = makeTempDoc(bad);
+    try {
+      assert.throws(() => parseModeDoc(path), /no '## nonexistent-template' section/);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('P1.2 — getPassTemplate resolves correctly per register', () => {
+  it('l1_l3 register returns overridden template', () => {
+    const { path, cleanup } = makeTempDoc(DOC_WITH_VARIANTS);
+    try {
+      const doc = parseModeDoc(path);
+      const template = getPassTemplate(doc, 'alpha', 'l1_l3');
+      assert.match(template, /L1-L3 alpha template body/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('l4_l5 register falls back to canonical pass_plan template', () => {
+    const { path, cleanup } = makeTempDoc(DOC_WITH_VARIANTS);
+    try {
+      const doc = parseModeDoc(path);
+      const template = getPassTemplate(doc, 'alpha', 'l4_l5');
+      assert.match(template, /L5 alpha template body/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('pass not in overrides falls back to canonical template', () => {
+    const { path, cleanup } = makeTempDoc(DOC_WITH_VARIANTS);
+    try {
+      const doc = parseModeDoc(path);
+      const template = getPassTemplate(doc, 'beta', 'l1_l3');  // beta not in l1_l3.overrides
+      assert.match(template, /Beta template body/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('mode doc without register_variants falls back to canonical for both bands', () => {
+    const { path, cleanup } = makeTempDoc(DOC_WITHOUT_VARIANTS);
+    try {
+      const doc = parseModeDoc(path);
+      const t1 = getPassTemplate(doc, 'alpha', 'l1_l3');
+      const t2 = getPassTemplate(doc, 'alpha', 'l4_l5');
+      assert.equal(t1, t2);
+      assert.match(t1, /legacy body/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('throws on unknown pass_id', () => {
+    const { path, cleanup } = makeTempDoc(DOC_WITH_VARIANTS);
+    try {
+      const doc = parseModeDoc(path);
+      assert.throws(() => getPassTemplate(doc, 'gamma', 'l1_l3'), /No pass with id 'gamma'/);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe('P1.2 — getTargetWordsForRegister', () => {
+  it('returns variant-specific target_words when declared', () => {
+    const { path, cleanup } = makeTempDoc(DOC_WITH_VARIANTS);
+    try {
+      const doc = parseModeDoc(path);
+      assert.deepEqual(getTargetWordsForRegister(doc, 'l1_l3'), { min: 9000, max: 11000 });
+      assert.deepEqual(getTargetWordsForRegister(doc, 'l4_l5'), { min: 12000, max: 15000 });
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('falls back to canonical target_words when variant absent', () => {
+    const { path, cleanup } = makeTempDoc(DOC_WITHOUT_VARIANTS);
+    try {
+      const doc = parseModeDoc(path);
+      assert.deepEqual(getTargetWordsForRegister(doc, 'l1_l3'), { min: 12000, max: 15000 });
+      assert.deepEqual(getTargetWordsForRegister(doc, 'l4_l5'), { min: 12000, max: 15000 });
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// P1.3 — Engine lexicons parser (#72)
+// ════════════════════════════════════════════════════════════════════════
+
+const FIXTURE_LEXICONS_MD = `# Engine Lexicons (test fixture)
+
+## vimshottari
+
+### L1-L3 register
+**Vocabulary**
+Mahadasha · Antardasha · Pratyantar
+
+**Voice rules**
+- Use traditional dasha vocabulary
+- Allow Sanskrit anchors
+
+### L4-L5 register
+**Vocabulary**
+phase-lock geometry · Cl(3) Vijnanamaya
+
+**Voice rules**
+- Framework-native register
+
+## human-design
+
+### L1-L3 register
+**Vocabulary**
+Type · Strategy · Authority · Centers
+
+**Voice rules**
+- Use HD traditional vocabulary
+
+### L4-L5 register
+**Vocabulary**
+electromagnetic channels · Pranamaya routing
+
+**Voice rules**
+- Framework-native
+
+## Lessons (autoresearch-appended)
+none yet
+`;
+
+describe('P1.3 — engine-lexicons-parser', () => {
+  it('parses all engine sections from a fixture file', () => {
+    const { path, cleanup } = makeTempDoc(FIXTURE_LEXICONS_MD);
+    try {
+      clearLexiconCache();
+      const parsed = parseLexicons(path);
+      assert.ok(parsed.engines.vimshottari);
+      assert.ok(parsed.engines['human-design']);
+    } finally {
+      cleanup();
+      clearLexiconCache();
+    }
+  });
+
+  it('skips non-engine sections (e.g., Lessons)', () => {
+    const { path, cleanup } = makeTempDoc(FIXTURE_LEXICONS_MD);
+    try {
+      clearLexiconCache();
+      const parsed = parseLexicons(path);
+      assert.equal(parsed.engines.lessons, undefined);
+    } finally {
+      cleanup();
+      clearLexiconCache();
+    }
+  });
+
+  it('extracts vocab + voice_rules per register band', () => {
+    const { path, cleanup } = makeTempDoc(FIXTURE_LEXICONS_MD);
+    try {
+      clearLexiconCache();
+      const lex = getEngineLexicon('vimshottari', 'l1_l3', path);
+      assert.match(lex.vocab, /Mahadasha · Antardasha/);
+      assert.match(lex.voice_rules, /traditional dasha vocabulary/);
+    } finally {
+      cleanup();
+      clearLexiconCache();
+    }
+  });
+
+  it('returns distinct content for l1_l3 vs l4_l5', () => {
+    const { path, cleanup } = makeTempDoc(FIXTURE_LEXICONS_MD);
+    try {
+      clearLexiconCache();
+      const l1 = getEngineLexicon('vimshottari', 'l1_l3', path);
+      const l5 = getEngineLexicon('vimshottari', 'l4_l5', path);
+      assert.notEqual(l1.vocab, l5.vocab);
+      assert.match(l5.vocab, /phase-lock geometry/);
+    } finally {
+      cleanup();
+      clearLexiconCache();
+    }
+  });
+
+  it('throws on unknown engine_id', () => {
+    const { path, cleanup } = makeTempDoc(FIXTURE_LEXICONS_MD);
+    try {
+      clearLexiconCache();
+      assert.throws(() => getEngineLexicon('unknown-engine' as any, 'l1_l3', path), /Unknown engine_id/);
+    } finally {
+      cleanup();
+      clearLexiconCache();
+    }
+  });
+
+  it('returns empty content for engines absent from the fixture (graceful degrade)', () => {
+    const { path, cleanup } = makeTempDoc(FIXTURE_LEXICONS_MD);
+    try {
+      clearLexiconCache();
+      const lex = getEngineLexicon('gene-keys', 'l1_l3', path);
+      assert.equal(lex.vocab, '');
+      assert.equal(lex.voice_rules, '');
+    } finally {
+      cleanup();
+      clearLexiconCache();
+    }
+  });
+
+  it('composeLexiconBlock combines multiple engines into one system-prompt block', () => {
+    const { path, cleanup } = makeTempDoc(FIXTURE_LEXICONS_MD);
+    try {
+      clearLexiconCache();
+      const block = composeLexiconBlock(['vimshottari', 'human-design'], 'l1_l3', path);
+      assert.match(block, /Engine Lexicons \(l1_l3\)/);
+      assert.match(block, /vimshottari \(l1_l3\)/);
+      assert.match(block, /human-design \(l1_l3\)/);
+      assert.match(block, /Mahadasha/);
+      assert.match(block, /Type · Strategy/);
+    } finally {
+      cleanup();
+      clearLexiconCache();
+    }
+  });
+
+  it('KNOWN_ENGINE_IDS has all 16 Selemene engines', () => {
+    assert.equal(KNOWN_ENGINE_IDS.length, 16);
+    for (const required of ['vimshottari', 'panchanga', 'human-design', 'gene-keys', 'tarot', 'i-ching']) {
+      assert.ok((KNOWN_ENGINE_IDS as ReadonlyArray<string>).includes(required), `missing ${required}`);
+    }
+  });
+
+  it('canonical engine-lexicons.md exists + parses cleanly (skeleton from P1.3)', () => {
+    clearLexiconCache();
+    const parsed = parseLexicons();   // uses default path
+    // Skeleton has all 16 engine headings, even if their content is TBD
+    for (const engine_id of KNOWN_ENGINE_IDS) {
+      assert.ok(
+        parsed.engines[engine_id] !== undefined,
+        `Skeleton missing engine section: ${engine_id}`,
+      );
+    }
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// P1.4 — API request/response contract (#73)
+// ════════════════════════════════════════════════════════════════════════
+
+describe('P1.4 — Reading request/response types compile + have expected shape', () => {
+  it('ReadingRequest accepts admin override field', () => {
+    const req: ReadingRequest = {
+      user_id: 'u1',
+      mode: 'partner-synastry',
+      subjects: [{ profile_id: 'p1' }, { profile_id: 'p2' }],
+      consciousness_level: 3,
+    };
+    assert.equal(req.consciousness_level, 3);
+  });
+
+  it('ReadingRequest accepts inline subject birth data', () => {
+    const req: ReadingRequest = {
+      user_id: 'u1',
+      mode: 'composite-dyad',
+      subjects: [
+        { subject: 'Alice', birth_date: '1990-01-01', birth_time: '12:00' },
+        { profile_id: 'p2' },
+      ],
+    };
+    assert.equal(req.subjects.length, 2);
+  });
+
+  it('ReadingResponse carries effective_consciousness_level + level_source + register_band', () => {
+    const res: ReadingResponse = {
+      reading_id: 'r1',
+      effective_consciousness_level: 3,
+      level_source: 'user_db',
+      register_band: 'l1_l3',
+      mode: 'partner-synastry',
+      total_words: 10000,
+      pass_metrics: [],
+      generated_at: '2026-05-15T00:00:00Z',
+    };
+    assert.equal(res.effective_consciousness_level, 3);
+    assert.equal(res.level_source, 'user_db');
+    assert.equal(res.register_band, 'l1_l3');
+  });
+
+  it('CallerIdentity is distinct from ReadingRequest (server-derived)', () => {
+    const caller: CallerIdentity = {
+      caller_id: 'admin-1',
+      caller_tier: 'initiate',
+      caller_is_admin: true,
+    };
+    assert.equal(caller.caller_tier, 'initiate');
+  });
+});


### PR DESCRIPTION
## Summary
Phase 1 of the consciousness-level register system. Lands all 4 contracts (level-resolver, mode-doc register-variant schema, engine-lexicons schema + parser, API request/response types) in one PR so P2 parallel-build swarms can start safely.

## Closes
- Closes #70 — P1.1 Level-resolver module
- Closes #71 — P1.2 Mode-doc register-variant schema
- Closes #72 — P1.3 Per-engine vocabulary lexicon schema (skeleton)
- Closes #73 — P1.4 API request/response contract

## What changed

**New**: \`scripts/integratedreading/level-resolver.ts\` (169 LOC)
- \`resolveLevel({user_id, admin_override, caller_tier, caller_is_admin, default_level, user_db_lookup})\` → \`{effective_level, source, register_band}\`
- Precedence: admin_override (if caller authorized) → user_db → default(1)
- **Security boundary**: admin_override only honored when caller has \`initiate\` tier or \`caller_is_admin: true\`. Non-admin override → 403 \`ForbiddenLevelOverrideError\`.
- Invalid levels (not int 1-5) → 400 \`InvalidConsciousnessLevelError\`

**Updated**: \`scripts/integratedreading/modes/parser.ts\` (+117 LOC)
- New types: \`RegisterBand\`, \`RegisterVariantSpec\`, \`RegisterVariants\`, \`PassTemplateOverride\`
- \`ModeConfig\` gains optional \`register_variants\` field
- \`getPassTemplate(doc, pass_id, register)\` resolves per-register templates
- \`getTargetWordsForRegister(doc, register)\` returns variant-specific or canonical range
- \`validateRegisterVariants\` enforces every override has matching pass_id + template section
- **Backward-compat**: mode docs without \`register_variants\` retain current behavior

**Updated**: \`scripts/integratedreading/modes/_schema.md\` (+36 lines)
- Documents the optional \`register_variants\` block + body-section conventions
- Field-reference table extended

**New**: \`scripts/integratedreading/engine-lexicons.md\` (321 lines — skeleton)
- All 16 engine sections present with L1-L3 + L4-L5 sub-sections
- Content TBD (filled in P2.3 #76)
- File-level schema documents the section structure

**New**: \`scripts/integratedreading/engine-lexicons-parser.ts\` (207 LOC)
- \`parseLexicons(path?)\` caches per-path
- \`getEngineLexicon(engine_id, register, path?)\` — throws on unknown engine
- \`composeLexiconBlock(engine_ids[], register, path?)\` — multi-engine assembly
- \`KNOWN_ENGINE_IDS\` const = all 16 Selemene engines

**New**: \`src/types/reading-request.ts\` (143 LOC)
- \`ReadingRequest\` (user_id, mode, subjects, optional consciousness_level)
- \`ReadingResponse\` (carries effective_consciousness_level + level_source + register_band for auditability)
- \`ReadingErrorResponse\` (typed error codes)
- \`CallerIdentity\` (server-derived; never from payload — spoof-safe)

**New**: \`tests/consciousness-level-contracts.test.ts\` (43 tests, all pass)

## Verification
- **562/562 tests pass** (43 new + 519 existing — no regressions)
- Skeleton engine-lexicons.md parses cleanly
- Mode docs without \`register_variants\` continue to behave identically
- All P1 deliverables compile under tsx + Node16 module resolution

## Test plan
- [ ] \`npm test\` → 562/562 pass
- [ ] Backward-compat check: existing reading flows produce identical output (no level field used)
- [ ] Auth boundary verified: non-admin caller passing \`consciousness_level\` → 403

## Out of scope
- Orchestrator level-branching (#74 P2.1)
- 6 mode-doc L1-L3 variants (#75 P2.2)
- Per-engine lexicon content (#76 P2.3)
- API endpoint implementations (#77 P2.4)
- Admin auth middleware (#78 P2.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)