### PR TITLE
P2.5 (#78) + P2.4 (#77): admin auth + API endpoint level support

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,154 @@
+// ─── /api/auth — Caller Identity + consciousness_level Gate ────────────
+//
+// SECURITY BOUNDARY
+// ─────────────────
+// This module is the perimeter that decides whether a request body's
+// `consciousness_level` field is honored. The level-resolver enforces
+// the SAME rule defensively, but the API gate runs FIRST so callers get
+// a clean 403 rather than a leaked stack trace.
+//
+// Threat model: an end-user on the `free` tier crafts an HTTP request
+// with `consciousness_level: 5` in the JSON body. Without this gate,
+// they would receive a reading at the framework-native register (4-5)
+// rather than the open-language register (1-3) their tier authorizes.
+//
+// Per design doc 2026-05-15-consciousness-level-register-design.md
+// § "Security boundary" and the level-resolver's matching block in
+// scripts/integratedreading/level-resolver.ts.
+//
+// Closes #78 (P2.5).
+//
+// ─── Identity derivation strategy ──────────────────────────────────────
+// Production deployments will replace this with JWT/OIDC/session
+// middleware. The current shape is a transitional dev-friendly mapping:
+//
+//   1. Headers (case-insensitive lookup):
+//        X-Caller-Id        → caller_id (string)
+//        X-Caller-Tier      → caller_tier (Tier enum, validated)
+//        X-Caller-Admin     → caller_is_admin ('1' | 'true' → true)
+//
+//   2. Environment escape hatch (LOCAL DEV ONLY):
+//        WITNESS_DEV_ADMIN=1 → caller_is_admin = true
+//        This MUST NOT be set in production. Document this in deploy
+//        runbooks — it is a deliberate dev affordance, not a backdoor.
+//
+//   3. Defaults:
+//        caller_id   → 'anonymous'
+//        caller_tier → 'free'
+//        caller_is_admin → false
+
+import { isCallerAdmin } from '../../scripts/integratedreading/level-resolver.js';
+import type { CallerIdentity, ReadingErrorResponse } from '../types/reading-request.js';
+import type { Tier } from '../types/interpretation.js';
+
+// ────────────────────────────────────────────────────────────────────────
+// Tier validation — keeps unknown values from leaking through
+// ────────────────────────────────────────────────────────────────────────
+
+const VALID_TIERS: ReadonlySet<Tier> = new Set<Tier>([
+  'free',
+  'subscriber',
+  'enterprise',
+  'initiate',
+]);
+
+function parseTier(value: unknown): Tier {
+  if (typeof value === 'string' && VALID_TIERS.has(value as Tier)) {
+    return value as Tier;
+  }
+  return 'free';
+}
+
+function parseBool(value: unknown): boolean {
+  if (typeof value !== 'string') return false;
+  const v = value.trim().toLowerCase();
+  return v === '1' || v === 'true' || v === 'yes';
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// deriveCallerIdentity
+// ────────────────────────────────────────────────────────────────────────
+
+export interface DeriveCallerIdentityInput {
+  /**
+   * HTTP request headers — keys MUST be lower-cased by the caller
+   * (matches `node:http` IncomingHttpHeaders convention).
+   */
+  headers: Record<string, string | string[] | undefined>;
+  /**
+   * Process environment subset. Pass `process.env` in production;
+   * pass `{}` or a stub in tests.
+   */
+  env: Record<string, string | undefined>;
+}
+
+/**
+ * Convert an incoming request's headers + env into a CallerIdentity.
+ *
+ * This is a PURE function — no I/O, no session lookups. Replace with a
+ * JWT-verifying middleware when real auth lands.
+ */
+export function deriveCallerIdentity(input: DeriveCallerIdentityInput): CallerIdentity {
+  const h = input.headers;
+  const rawId = h['x-caller-id'];
+  const rawTier = h['x-caller-tier'];
+  const rawAdmin = h['x-caller-admin'];
+
+  const caller_id =
+    (typeof rawId === 'string' && rawId.trim()) ||
+    (Array.isArray(rawId) && rawId[0]) ||
+    'anonymous';
+
+  const caller_tier = parseTier(Array.isArray(rawTier) ? rawTier[0] : rawTier);
+
+  let caller_is_admin = parseBool(Array.isArray(rawAdmin) ? rawAdmin[0] : rawAdmin);
+
+  // Dev escape hatch — see header comment block.
+  if (parseBool(input.env.WITNESS_DEV_ADMIN)) {
+    caller_is_admin = true;
+  }
+
+  return { caller_id, caller_tier, caller_is_admin };
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// gateConsciousnessLevelOverride
+// ────────────────────────────────────────────────────────────────────────
+
+export interface GateResult {
+  status: 403;
+  body: ReadingErrorResponse;
+}
+
+/**
+ * Returns a 403 response object if the body contains `consciousness_level`
+ * but the caller is not authorized to override. Returns `null` when the
+ * gate passes (either the field is absent, or the caller is admin).
+ *
+ * Call BEFORE invoking the orchestrator. The level-resolver also enforces
+ * this rule, but a clean 403 from the API layer beats a thrown error.
+ */
+export function gateConsciousnessLevelOverride(
+  body: { consciousness_level?: unknown },
+  caller: Pick<CallerIdentity, 'caller_id' | 'caller_tier' | 'caller_is_admin'>,
+): GateResult | null {
+  const override = body?.consciousness_level;
+  if (override === undefined || override === null) return null;
+
+  if (isCallerAdmin(caller)) return null;
+
+  return {
+    status: 403,
+    body: {
+      error:
+        `consciousness_level override requires admin role or initiate tier. ` +
+        `caller_id='${caller.caller_id}', caller_tier='${caller.caller_tier}', ` +
+        `caller_is_admin=${caller.caller_is_admin}`,
+      code: 'FORBIDDEN_LEVEL_OVERRIDE',
+      details: {
+        caller_tier: caller.caller_tier,
+        attempted_override: override,
+      },
+    },
+  };
+}

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -13,6 +13,15 @@ import type {
   Kosha,
 } from '../types/interpretation.js';
 import type { SelemeneEngineId, BirthData } from '../types/engine.js';
+import type {
+  ConsciousnessLevel,
+  LevelSource,
+  RegisterBand,
+  ReadingErrorResponse,
+  CallerIdentity,
+} from '../types/reading-request.js';
+import { resolveLevel } from '../../scripts/integratedreading/level-resolver.js';
+import { deriveCallerIdentity, gateConsciousnessLevelOverride } from './auth.js';
 
 // ═══════════════════════════════════════════════════════════════════════
 // API TYPES
@@ -31,6 +40,11 @@ export interface InterpretRequest {
     longitude?: number;
     timezone?: string;
   };
+  /**
+   * Optional admin override (1-5). Gated server-side — non-admin callers
+   * receive HTTP 403 FORBIDDEN_LEVEL_OVERRIDE. See src/api/auth.ts.
+   */
+  consciousness_level?: ConsciousnessLevel;
 }
 
 export interface MobileInterpretation {
@@ -49,6 +63,10 @@ export interface MobileInterpretation {
   graduation_prompt?: string;
   // Somatic nudge (Pichet)
   somatic_nudge?: string;        // ≤140 chars body-awareness micro-prompt
+  // Resolved consciousness-level register (P2.4 / #77). Always present.
+  effective_consciousness_level?: ConsciousnessLevel;
+  level_source?: LevelSource;
+  register_band?: RegisterBand;
 }
 
 export interface HeartbeatResponse {
@@ -222,6 +240,15 @@ export interface ApiDependencies {
   getUserState: (userId: string) => Promise<UserState>;
   getTierForUser: (userId: string) => Promise<Tier>;
   processAkshara?: (req: MirrorRequest) => Promise<MirrorResponse>;
+  /**
+   * Optional user-DB stored consciousness_level lookup (P2.4 / #77).
+   * Returns the user's stored level (1-5) or undefined when not found.
+   * If not provided, the resolver falls back to `default_level` (1).
+   *
+   * TODO: Wire this to Selemene DB once user-profile schema lands;
+   * currently no central user-profile fetcher exists in this codebase.
+   */
+  getUserConsciousnessLevel?: (userId: string) => number | undefined;
 }
 
 /**
@@ -235,9 +262,37 @@ export function createApiHandlers(deps: ApiDependencies) {
   return {
     /**
      * POST /interpret
-     * Main interpretation endpoint — sends query through the full pipeline
+     * Main interpretation endpoint — sends query through the full pipeline.
+     *
+     * P2.5 (#78): Gates `consciousness_level` payload. Non-admin callers
+     *             passing the field receive 403 FORBIDDEN_LEVEL_OVERRIDE.
+     * P2.4 (#77): Resolves the effective consciousness_level and includes
+     *             it in the response (effective_consciousness_level,
+     *             level_source, register_band).
      */
-    async interpret(req: InterpretRequest): Promise<{ status: number; body: MobileInterpretation }> {
+    async interpret(
+      req: InterpretRequest,
+      caller?: CallerIdentity,
+    ): Promise<{ status: number; body: MobileInterpretation | ReadingErrorResponse }> {
+      // ── P2.5 gate ─────────────────────────────────────────────────
+      const callerId: CallerIdentity = caller ?? {
+        caller_id: req.user_id,
+        caller_tier: 'free',
+        caller_is_admin: false,
+      };
+      const gateBlock = gateConsciousnessLevelOverride(req, callerId);
+      if (gateBlock) return gateBlock;
+
+      // ── P2.4 level resolution ─────────────────────────────────────
+      const resolved = resolveLevel({
+        user_id: req.user_id,
+        admin_override: req.consciousness_level,
+        caller_tier: callerId.caller_tier,
+        caller_is_admin: callerId.caller_is_admin,
+        default_level: 1,
+        user_db_lookup: deps.getUserConsciousnessLevel,
+      });
+
       const userState = await deps.getUserState(req.user_id);
 
       const birthData: BirthData = req.birth_data
@@ -262,6 +317,11 @@ export function createApiHandlers(deps: ApiDependencies) {
 
       const interp = await deps.processPipeline(pipelineQuery);
       const mobile = condenser.condense(interp);
+
+      // Attach resolved level metadata to every response (P2.4)
+      mobile.effective_consciousness_level = resolved.effective_level;
+      mobile.level_source = resolved.source;
+      mobile.register_band = resolved.register_band;
 
       // Track heartbeat
       heartbeatState[req.user_id] = {
@@ -368,7 +428,12 @@ export async function createServer(config: ServerConfig): Promise<{
 
       if (path === '/interpret' && req.method === 'POST') {
         const body = await readBody(req);
-        const result = await config.handlers.interpret(body as InterpretRequest);
+        // Derive caller identity from headers (P2.5 / #78).
+        const caller = deriveCallerIdentity({
+          headers: req.headers as Record<string, string | string[] | undefined>,
+          env: process.env,
+        });
+        const result = await config.handlers.interpret(body as InterpretRequest, caller);
         res.writeHead(result.status);
         res.end(JSON.stringify(result.body));
       } else if (path === '/heartbeat' && req.method === 'GET') {

--- a/src/standalone/standalone-api.ts
+++ b/src/standalone/standalone-api.ts
@@ -55,6 +55,17 @@ import { CONSCIOUSNESS_TO_KOSHA } from '../types/interpretation.js';
 import { ENGINE_ROUTING } from '../types/engine.js';
 import { createLLMProvider, resolveProviderChoice } from '../inference/provider-factory.js';
 import type { LLMProvider } from '../inference/types.js';
+import type {
+  CallerIdentity,
+  ConsciousnessLevel,
+  LevelSource,
+  RegisterBand,
+} from '../types/reading-request.js';
+import {
+  resolveLevel,
+  ForbiddenLevelOverrideError,
+} from '../../scripts/integratedreading/level-resolver.js';
+import { deriveCallerIdentity, gateConsciousnessLevelOverride } from '../api/auth.js';
 
 // ═══════════════════════════════════════════════════════════════════════
 // API TYPES
@@ -67,6 +78,14 @@ export interface StandaloneApiConfig extends DailyMirrorConfig {
   knowledge_path?: string;       // Default: ../../knowledge from this module
   llm_timeout_ms?: number;       // Optional override for proxy LLM inference timeout
   llm_provider_instance?: LLMProvider; // Optional injection for tests / custom wiring
+  /**
+   * Optional user-DB stored consciousness_level lookup (P2.4 / #77).
+   * Returns the user's stored level (1-5) or undefined if not found.
+   *
+   * TODO: Wire to Selemene DB once user-profile schema lands. Until then
+   *       this is undefined and the resolver falls back to default 1.
+   */
+  get_user_consciousness_level?: (userId: string) => number | undefined;
   // Rhythm SSE server config (optional — rhythm endpoints disabled if not provided)
   rhythm?: {
     poll_interval_ms?: number;   // Default: 120_000 (2 min)
@@ -81,6 +100,27 @@ export interface ReadingRequest {
   latitude?: number;        // Default: 0
   longitude?: number;       // Default: 0
   timezone?: string;        // Default: 'UTC'
+  /**
+   * Optional admin override (1-5) per P2.4 (#77). Gated server-side —
+   * non-admin callers receive HTTP 403 FORBIDDEN_LEVEL_OVERRIDE.
+   * See src/api/auth.ts and scripts/integratedreading/level-resolver.ts.
+   */
+  consciousness_level?: ConsciousnessLevel;
+  /**
+   * Optional user_id used for stored-level lookup. When absent, the
+   * resolver falls back to `default_level` (1, uninitiated).
+   */
+  user_id?: string;
+}
+
+/**
+ * Resolved consciousness-level metadata attached to every successful
+ * reading response (P2.4 / #77).
+ */
+export interface ReadingLevelMeta {
+  effective_consciousness_level: ConsciousnessLevel;
+  level_source: LevelSource;
+  register_band: RegisterBand;
 }
 
 export interface ApiError {
@@ -227,6 +267,20 @@ function validateReadingRequest(body: unknown): ReadingRequest | ApiError {
     req.birth_time = timeStr;
   }
   
+  // consciousness_level: validate shape if present; gate happens later.
+  let consciousness_level: ConsciousnessLevel | undefined;
+  if (req.consciousness_level !== undefined && req.consciousness_level !== null) {
+    const v = req.consciousness_level;
+    if (typeof v !== 'number' || !Number.isInteger(v) || v < 1 || v > 5) {
+      return {
+        error: 'consciousness_level must be an integer 1-5',
+        code: 'INVALID_CONSCIOUSNESS_LEVEL',
+        hint: 'Allowed values: 1, 2, 3, 4, 5',
+      };
+    }
+    consciousness_level = v as ConsciousnessLevel;
+  }
+
   return {
     birth_date: req.birth_date as string,
     birth_time: req.birth_time as string | undefined,
@@ -234,6 +288,8 @@ function validateReadingRequest(body: unknown): ReadingRequest | ApiError {
     latitude: typeof req.latitude === 'number' ? req.latitude : 0,
     longitude: typeof req.longitude === 'number' ? req.longitude : 0,
     timezone: (req.timezone as string) || 'UTC',
+    consciousness_level,
+    user_id: typeof req.user_id === 'string' ? req.user_id : undefined,
   };
 }
 
@@ -1567,7 +1623,65 @@ export function createStandaloneHandlers(config: StandaloneApiConfig) {
     const maxLayer = computeMaxLayer(decoderState, config.tier);
     return { birthData, decoderState, maxLayer, userHash };
   }
-  
+
+  // ─── P2.5 / P2.4: consciousness_level gate + resolution helper ────
+  // Applies the auth gate to a validated reading request, then resolves
+  // the effective consciousness_level. Returns either a 403 gate response
+  // (caller should short-circuit) or the resolved ReadingLevelMeta.
+  function applyLevelGate(
+    validated: ReadingRequest,
+    caller: CallerIdentity,
+  ): { gate: { status: 403; body: ApiError } } | { meta: ReadingLevelMeta } {
+    const gateBlock = gateConsciousnessLevelOverride(
+      { consciousness_level: validated.consciousness_level },
+      caller,
+    );
+    if (gateBlock) {
+      return {
+        gate: {
+          status: 403,
+          body: {
+            error: gateBlock.body.error,
+            code: gateBlock.body.code,
+            hint: 'consciousness_level overrides require admin role or initiate tier.',
+          } satisfies ApiError,
+        },
+      };
+    }
+    try {
+      const resolved = resolveLevel({
+        user_id: validated.user_id ?? 'anonymous',
+        admin_override: validated.consciousness_level,
+        caller_tier: caller.caller_tier,
+        caller_is_admin: caller.caller_is_admin,
+        default_level: 1,
+        user_db_lookup: config.get_user_consciousness_level,
+      });
+      return {
+        meta: {
+          effective_consciousness_level: resolved.effective_level,
+          level_source: resolved.source,
+          register_band: resolved.register_band,
+        },
+      };
+    } catch (err) {
+      // Defense-in-depth — gate above should already have caught this,
+      // but the resolver throws on its own when bypassed in tests.
+      if (err instanceof ForbiddenLevelOverrideError) {
+        return {
+          gate: {
+            status: 403,
+            body: {
+              error: err.message,
+              code: 'FORBIDDEN_LEVEL_OVERRIDE',
+            } satisfies ApiError,
+          },
+        };
+      }
+      throw err;
+    }
+  }
+
   return {
     /**
      * GET / — Product info and available engines
@@ -1605,13 +1719,30 @@ export function createStandaloneHandlers(config: StandaloneApiConfig) {
     
     /**
      * POST /reading — Generate daily reading (primary engine selected by rotation)
+     *
+     * P2.5 (#78): Gates `consciousness_level` payload field — non-admin
+     *             callers receive 403 FORBIDDEN_LEVEL_OVERRIDE.
+     * P2.4 (#77): Resolves effective level + includes meta in response.
      */
-    async reading(body: unknown, clientKey?: string): Promise<{ status: number; body: unknown }> {
+    async reading(
+      body: unknown,
+      clientKey?: string,
+      caller?: CallerIdentity,
+    ): Promise<{ status: number; body: unknown }> {
       const validated = validateReadingRequest(body);
       if ('error' in validated) {
         return { status: 400, body: validated };
       }
-      
+
+      const effectiveCaller: CallerIdentity = caller ?? {
+        caller_id: validated.user_id ?? 'anonymous',
+        caller_tier: 'free',
+        caller_is_admin: false,
+      };
+      const gated = applyLevelGate(validated, effectiveCaller);
+      if ('gate' in gated) return gated.gate;
+      const levelMeta = gated.meta;
+
       const limitKey = clientKey || validated.birth_date;
       if (!checkRateLimit(limitKey, rateLimit)) {
         return {
@@ -1623,15 +1754,16 @@ export function createStandaloneHandlers(config: StandaloneApiConfig) {
           } satisfies ApiError,
         };
       }
-      
+
       try {
         const birthData = toBirthData(validated);
         const reading = await mirror.generateReading(birthData);
-        
+
         return {
           status: 200,
           body: {
             reading,
+            ...levelMeta,
             next_reading_available: getNextMidnight(),
             full_platform_url: 'https://tryambakam.space',
           },
@@ -1655,6 +1787,7 @@ export function createStandaloneHandlers(config: StandaloneApiConfig) {
       engineId: string,
       body: unknown,
       clientKey?: string,
+      caller?: CallerIdentity,
     ): Promise<{ status: number; body: unknown }> {
       // Validate engine ID
       if (!STANDALONE_ENGINES.includes(engineId as StandaloneEngineId)) {
@@ -1667,12 +1800,21 @@ export function createStandaloneHandlers(config: StandaloneApiConfig) {
           } satisfies ApiError,
         };
       }
-      
+
       const validated = validateReadingRequest(body);
       if ('error' in validated) {
         return { status: 400, body: validated };
       }
-      
+
+      const effectiveCaller: CallerIdentity = caller ?? {
+        caller_id: validated.user_id ?? 'anonymous',
+        caller_tier: 'free',
+        caller_is_admin: false,
+      };
+      const gated = applyLevelGate(validated, effectiveCaller);
+      if ('gate' in gated) return gated.gate;
+      const levelMeta = gated.meta;
+
       const limitKey = clientKey || validated.birth_date;
       if (!checkRateLimit(limitKey, rateLimit)) {
         return {
@@ -1680,15 +1822,15 @@ export function createStandaloneHandlers(config: StandaloneApiConfig) {
           body: { error: 'Rate limit exceeded', code: 'RATE_LIMITED' } satisfies ApiError,
         };
       }
-      
+
       try {
         const birthData = toBirthData(validated);
         const reading = await mirror.generateEngineReading(
           birthData,
           engineId as StandaloneEngineId,
         );
-        
-        return { status: 200, body: { reading } };
+
+        return { status: 200, body: { reading, ...levelMeta } };
       } catch (err) {
         return {
           status: 500,
@@ -1704,23 +1846,39 @@ export function createStandaloneHandlers(config: StandaloneApiConfig) {
     async *readingStream(
       body: unknown,
       clientKey?: string,
+      caller?: CallerIdentity,
     ): AsyncGenerator<string, void, unknown> {
       const validated = validateReadingRequest(body);
       if ('error' in validated) {
         yield `event: error\ndata: ${JSON.stringify(validated)}\n\n`;
         return;
       }
-      
+
+      const effectiveCaller: CallerIdentity = caller ?? {
+        caller_id: validated.user_id ?? 'anonymous',
+        caller_tier: 'free',
+        caller_is_admin: false,
+      };
+      const gated = applyLevelGate(validated, effectiveCaller);
+      if ('gate' in gated) {
+        yield `event: error\ndata: ${JSON.stringify(gated.gate.body)}\n\n`;
+        return;
+      }
+      const levelMeta = gated.meta;
+
       const limitKey = clientKey || validated.birth_date;
       if (!checkRateLimit(limitKey, rateLimit)) {
         yield `event: error\ndata: ${JSON.stringify({ error: 'Rate limit exceeded', code: 'RATE_LIMITED' })}\n\n`;
         return;
       }
-      
+
       try {
         const birthData = toBirthData(validated);
         const reading = await mirror.generateReading(birthData);
-        
+
+        // Send resolved level meta first so clients know the register.
+        yield `event: level\ndata: ${JSON.stringify(levelMeta)}\n\n`;
+
         // Send Layer 1 immediately
         yield `event: layer1\ndata: ${JSON.stringify({ primary_reading: reading.primary_reading, all_readings: reading.all_readings })}\n\n`;
         
@@ -2178,25 +2336,37 @@ export async function createStandaloneServer(config: StandaloneApiConfig): Promi
         
       } else if (path === '/reading' && req.method === 'POST') {
         const body = await readBody(req);
-        const result = await handlers.reading(body);
+        const caller = deriveCallerIdentity({
+          headers: req.headers as Record<string, string | string[] | undefined>,
+          env: process.env,
+        });
+        const result = await handlers.reading(body, undefined, caller);
         res.writeHead(result.status);
         res.end(JSON.stringify(result.body));
-        
+
       } else if (path === '/reading/stream' && req.method === 'POST') {
         const body = await readBody(req);
+        const caller = deriveCallerIdentity({
+          headers: req.headers as Record<string, string | string[] | undefined>,
+          env: process.env,
+        });
         res.setHeader('Content-Type', 'text/event-stream');
         res.setHeader('Cache-Control', 'no-cache');
         res.setHeader('Connection', 'keep-alive');
         res.writeHead(200);
-        for await (const event of handlers.readingStream(body)) {
+        for await (const event of handlers.readingStream(body, undefined, caller)) {
           res.write(event);
         }
         res.end();
-        
+
       } else if (path.startsWith('/reading/') && req.method === 'POST') {
         const engineId = path.split('/')[2];
         const body = await readBody(req);
-        const result = await handlers.engineReading(engineId, body);
+        const caller = deriveCallerIdentity({
+          headers: req.headers as Record<string, string | string[] | undefined>,
+          env: process.env,
+        });
+        const result = await handlers.engineReading(engineId, body, undefined, caller);
         res.writeHead(result.status);
         res.end(JSON.stringify(result.body));
         

--- a/tests/admin-auth-path.test.ts
+++ b/tests/admin-auth-path.test.ts
@@ -1,0 +1,147 @@
+// ─── P2.5 — Admin Auth Path Tests (#78) ───────────────────────────────
+// Verifies the auth middleware that gates the `consciousness_level`
+// payload override field. Non-admin callers MUST NOT be able to escalate
+// their reading register by editing the request body.
+//
+// Per design doc 2026-05-15-consciousness-level-register-design.md
+// § "Security boundary" and the level-resolver's SECURITY BOUNDARY
+// comment block (scripts/integratedreading/level-resolver.ts).
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  deriveCallerIdentity,
+  gateConsciousnessLevelOverride,
+} from '../src/api/auth.js';
+
+// ════════════════════════════════════════════════════════════════════════
+// deriveCallerIdentity — converts headers/env into a CallerIdentity
+// ════════════════════════════════════════════════════════════════════════
+
+describe('P2.5 — deriveCallerIdentity', () => {
+  it('returns anonymous free-tier identity when no headers supplied', () => {
+    const id = deriveCallerIdentity({ headers: {}, env: {} });
+    assert.equal(id.caller_tier, 'free');
+    assert.equal(id.caller_is_admin, false);
+    assert.ok(id.caller_id.length > 0);
+  });
+
+  it('reads X-Caller-Tier header', () => {
+    const id = deriveCallerIdentity({
+      headers: { 'x-caller-tier': 'subscriber' },
+      env: {},
+    });
+    assert.equal(id.caller_tier, 'subscriber');
+    assert.equal(id.caller_is_admin, false);
+  });
+
+  it('reads X-Caller-Admin header as boolean true', () => {
+    const id = deriveCallerIdentity({
+      headers: { 'x-caller-admin': '1' },
+      env: {},
+    });
+    assert.equal(id.caller_is_admin, true);
+  });
+
+  it('initiate tier callers are treated as admin via tier (not explicit flag)', () => {
+    const id = deriveCallerIdentity({
+      headers: { 'x-caller-tier': 'initiate' },
+      env: {},
+    });
+    assert.equal(id.caller_tier, 'initiate');
+    // caller_is_admin is the explicit flag — initiate tier is admin
+    // through the isCallerAdmin() check, not by promoting this field.
+    assert.equal(id.caller_is_admin, false);
+  });
+
+  it('WITNESS_DEV_ADMIN=1 env-flag promotes caller_is_admin to true', () => {
+    const id = deriveCallerIdentity({
+      headers: {},
+      env: { WITNESS_DEV_ADMIN: '1' },
+    });
+    assert.equal(id.caller_is_admin, true);
+  });
+
+  it('WITNESS_DEV_ADMIN=0 does NOT promote', () => {
+    const id = deriveCallerIdentity({
+      headers: {},
+      env: { WITNESS_DEV_ADMIN: '0' },
+    });
+    assert.equal(id.caller_is_admin, false);
+  });
+
+  it('uses X-Caller-Id when supplied', () => {
+    const id = deriveCallerIdentity({
+      headers: { 'x-caller-id': 'admin-jane' },
+      env: {},
+    });
+    assert.equal(id.caller_id, 'admin-jane');
+  });
+
+  it('falls back to free tier on unknown tier value', () => {
+    const id = deriveCallerIdentity({
+      headers: { 'x-caller-tier': 'celestial-pirate' },
+      env: {},
+    });
+    assert.equal(id.caller_tier, 'free');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// gateConsciousnessLevelOverride — pure gate function
+// ════════════════════════════════════════════════════════════════════════
+
+describe('P2.5 — gateConsciousnessLevelOverride', () => {
+  it('non-admin caller + consciousness_level: 5 → 403 FORBIDDEN_LEVEL_OVERRIDE', () => {
+    const result = gateConsciousnessLevelOverride(
+      { consciousness_level: 5 },
+      { caller_id: 'user-1', caller_tier: 'free', caller_is_admin: false },
+    );
+    assert.notEqual(result, null);
+    assert.equal(result?.status, 403);
+    assert.equal(result?.body.code, 'FORBIDDEN_LEVEL_OVERRIDE');
+    assert.match(result?.body.error ?? '', /admin/i);
+  });
+
+  it('subscriber tier + consciousness_level: 3 → 403 (still non-admin)', () => {
+    const result = gateConsciousnessLevelOverride(
+      { consciousness_level: 3 },
+      { caller_id: 'sub-1', caller_tier: 'subscriber', caller_is_admin: false },
+    );
+    assert.equal(result?.status, 403);
+    assert.equal(result?.body.code, 'FORBIDDEN_LEVEL_OVERRIDE');
+  });
+
+  it('initiate tier + consciousness_level: 3 → null (passes gate)', () => {
+    const result = gateConsciousnessLevelOverride(
+      { consciousness_level: 3 },
+      { caller_id: 'init-1', caller_tier: 'initiate', caller_is_admin: false },
+    );
+    assert.equal(result, null);
+  });
+
+  it('caller_is_admin=true + consciousness_level: 5 → null (passes gate)', () => {
+    const result = gateConsciousnessLevelOverride(
+      { consciousness_level: 5 },
+      { caller_id: 'admin-1', caller_tier: 'free', caller_is_admin: true },
+    );
+    assert.equal(result, null);
+  });
+
+  it('no consciousness_level in body → null regardless of caller tier', () => {
+    const result = gateConsciousnessLevelOverride(
+      { user_id: 'u', mode: 'single' },
+      { caller_id: 'anon', caller_tier: 'free', caller_is_admin: false },
+    );
+    assert.equal(result, null);
+  });
+
+  it('consciousness_level: undefined explicitly → null', () => {
+    const result = gateConsciousnessLevelOverride(
+      { consciousness_level: undefined },
+      { caller_id: 'anon', caller_tier: 'free', caller_is_admin: false },
+    );
+    assert.equal(result, null);
+  });
+});

--- a/tests/api-endpoints-level.test.ts
+++ b/tests/api-endpoints-level.test.ts
@@ -1,0 +1,217 @@
+// ─── P2.4 — API endpoint consciousness_level integration (#77) ─────────
+// End-to-end check that the reading endpoints:
+//   1. Accept optional consciousness_level: 1-5 in the payload
+//   2. Resolve the effective level via the level-resolver
+//   3. Return effective_consciousness_level + level_source + register_band
+//   4. Honor the P2.5 gate (non-admin override → 403)
+//
+// Per design doc 2026-05-15-consciousness-level-register-design.md.
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { createStandaloneHandlers, _resetRateLimiter } from '../src/standalone/standalone-api.js';
+import type { CallerIdentity } from '../src/types/reading-request.js';
+
+// Use a minimal config — the handlers don't need real Selemene for the
+// reading paths because mirror.generateReading() runs against stub data.
+function mkHandlers(overrides: Partial<Parameters<typeof createStandaloneHandlers>[0]> = {}) {
+  _resetRateLimiter();
+  return createStandaloneHandlers({
+    selemene_url: 'http://localhost:9999',  // never called in unit tests
+    selemene_api_key: 'test',
+    tier: 'witness-initiate',
+    rate_limit_per_hour: 1000,
+    ...overrides,
+  });
+}
+
+const adminCaller: CallerIdentity = {
+  caller_id: 'admin-1',
+  caller_tier: 'initiate',
+  caller_is_admin: false,  // initiate-tier is admin via the resolver
+};
+
+const freeCaller: CallerIdentity = {
+  caller_id: 'free-1',
+  caller_tier: 'free',
+  caller_is_admin: false,
+};
+
+// ════════════════════════════════════════════════════════════════════════
+// POST /reading — base endpoint
+// ════════════════════════════════════════════════════════════════════════
+
+describe('P2.4 — POST /reading', () => {
+  it('no consciousness_level + no lookup → level_source: "default", level 1', async () => {
+    const handlers = mkHandlers();
+    const result = await handlers.reading(
+      { birth_date: '1991-08-13', birth_time: '13:19' },
+      'test-key-1',
+      freeCaller,
+    );
+    assert.equal(result.status, 200);
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body.effective_consciousness_level, 1);
+    assert.equal(body.level_source, 'default');
+    assert.equal(body.register_band, 'l1_l3');
+  });
+
+  it('user_db_lookup returns 2 → level_source: "user_db", level 2', async () => {
+    const handlers = mkHandlers({
+      get_user_consciousness_level: (uid) => (uid === 'sub-user' ? 2 : undefined),
+    });
+    const result = await handlers.reading(
+      { birth_date: '1991-08-13', user_id: 'sub-user' },
+      'test-key-2',
+      freeCaller,
+    );
+    assert.equal(result.status, 200);
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body.effective_consciousness_level, 2);
+    assert.equal(body.level_source, 'user_db');
+    assert.equal(body.register_band, 'l1_l3');
+  });
+
+  it('admin caller + consciousness_level: 3 → admin_override path, level 3, l1_l3 band', async () => {
+    const handlers = mkHandlers();
+    const result = await handlers.reading(
+      { birth_date: '1991-08-13', consciousness_level: 3 },
+      'test-key-3',
+      adminCaller,
+    );
+    assert.equal(result.status, 200);
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body.effective_consciousness_level, 3);
+    assert.equal(body.level_source, 'admin_override');
+    assert.equal(body.register_band, 'l1_l3');
+  });
+
+  it('admin caller + consciousness_level: 5 → admin_override path, level 5, l4_l5 band', async () => {
+    const handlers = mkHandlers();
+    const result = await handlers.reading(
+      { birth_date: '1991-08-13', consciousness_level: 5 },
+      'test-key-4',
+      adminCaller,
+    );
+    assert.equal(result.status, 200);
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body.effective_consciousness_level, 5);
+    assert.equal(body.level_source, 'admin_override');
+    assert.equal(body.register_band, 'l4_l5');
+  });
+
+  it('non-admin caller + consciousness_level: 5 → 403 FORBIDDEN_LEVEL_OVERRIDE', async () => {
+    const handlers = mkHandlers();
+    const result = await handlers.reading(
+      { birth_date: '1991-08-13', consciousness_level: 5 },
+      'test-key-5',
+      freeCaller,
+    );
+    assert.equal(result.status, 403);
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body.code, 'FORBIDDEN_LEVEL_OVERRIDE');
+  });
+
+  it('invalid consciousness_level (out-of-range) → 400 INVALID_CONSCIOUSNESS_LEVEL', async () => {
+    const handlers = mkHandlers();
+    const result = await handlers.reading(
+      { birth_date: '1991-08-13', consciousness_level: 7 },
+      'test-key-6',
+      adminCaller,
+    );
+    assert.equal(result.status, 400);
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body.code, 'INVALID_CONSCIOUSNESS_LEVEL');
+  });
+
+  it('regression: existing payload with no consciousness_level field still works', async () => {
+    const handlers = mkHandlers();
+    const result = await handlers.reading(
+      { birth_date: '1991-08-13', birth_time: '13:19', latitude: 12.97, longitude: 77.59, timezone: 'Asia/Kolkata' },
+      'test-key-7',
+    );
+    assert.equal(result.status, 200);
+    const body = result.body as Record<string, unknown>;
+    assert.ok(body.reading);
+    assert.ok(body.next_reading_available);
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// POST /reading/:engine_id
+// ════════════════════════════════════════════════════════════════════════
+
+describe('P2.4 — POST /reading/:engine_id', () => {
+  // NOTE: The happy-path engine reading requires a live Selemene
+  // endpoint (the per-engine generateEngineReading() hits the network).
+  // The unit tests below cover the policy paths that don't require it:
+  // 1) the P2.5 gate fires before the engine runs (403), and
+  // 2) invalid engine IDs are rejected at the policy layer.
+
+  it('non-admin override on per-engine endpoint → 403 (gate runs before engine)', async () => {
+    const handlers = mkHandlers();
+    const result = await handlers.engineReading(
+      'biorhythm',
+      { birth_date: '1991-08-13', consciousness_level: 4 },
+      'engine-key-3',
+      freeCaller,
+    );
+    assert.equal(result.status, 403);
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body.code, 'FORBIDDEN_LEVEL_OVERRIDE');
+  });
+
+  it('invalid engine + admin override → still rejected as INVALID_ENGINE (engine check runs first)', async () => {
+    const handlers = mkHandlers();
+    const result = await handlers.engineReading(
+      'tarot',
+      { birth_date: '1991-08-13', consciousness_level: 4 },
+      'engine-key-4',
+      adminCaller,
+    );
+    assert.equal(result.status, 400);
+    const body = result.body as Record<string, unknown>;
+    assert.equal(body.code, 'INVALID_ENGINE');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// POST /reading/stream — SSE
+// ════════════════════════════════════════════════════════════════════════
+
+describe('P2.4 — POST /reading/stream', () => {
+  it('emits a `level` SSE event with resolved meta before layer1', async () => {
+    const handlers = mkHandlers();
+    const events: string[] = [];
+    for await (const ev of handlers.readingStream(
+      { birth_date: '1991-08-13', consciousness_level: 2 },
+      'stream-key-1',
+      adminCaller,
+    )) {
+      events.push(ev);
+    }
+    const levelEvent = events.find((e) => e.startsWith('event: level\n'));
+    assert.ok(levelEvent, 'expected a level event in the SSE stream');
+    const payload = JSON.parse(levelEvent!.split('data: ')[1].trim());
+    assert.equal(payload.effective_consciousness_level, 2);
+    assert.equal(payload.level_source, 'admin_override');
+    assert.equal(payload.register_band, 'l1_l3');
+  });
+
+  it('non-admin override on stream → emits SSE error event with FORBIDDEN_LEVEL_OVERRIDE', async () => {
+    const handlers = mkHandlers();
+    const events: string[] = [];
+    for await (const ev of handlers.readingStream(
+      { birth_date: '1991-08-13', consciousness_level: 5 },
+      'stream-key-2',
+      freeCaller,
+    )) {
+      events.push(ev);
+    }
+    const errorEvent = events.find((e) => e.startsWith('event: error\n'));
+    assert.ok(errorEvent, 'expected an error event on the SSE stream');
+    const payload = JSON.parse(errorEvent!.split('data: ')[1].trim());
+    assert.equal(payload.code, 'FORBIDDEN_LEVEL_OVERRIDE');
+  });
+});


### PR DESCRIPTION
## Summary

Bundles two P2 issues that both touch the API server surface so we don't have merge conflicts on `src/api/server.ts` / `src/standalone/standalone-api.ts`:

- **P2.5 (#78)** — Admin auth path: gates the `consciousness_level` payload field so only admin/initiate callers can override the user's reading register.
- **P2.4 (#77)** — API endpoint integration: wires the level-resolver through the reading endpoints and returns `effective_consciousness_level` + `level_source` + `register_band` in every reading response.

Built on the P1 contracts merged in #81. Other P2 work (P2.1 orchestrator, P2.2 mode docs, P2.3 engine lexicons) is in parallel branches and is **not** touched here.

## P2.5 — Admin auth path (#78)

**New module:** `src/api/auth.ts`

- `deriveCallerIdentity({headers, env})` — pure function that converts request headers (`X-Caller-Id`, `X-Caller-Tier`, `X-Caller-Admin`) + env (`WITNESS_DEV_ADMIN=1` for local dev) into a `CallerIdentity` (`caller_id`, `caller_tier`, `caller_is_admin`). Unknown tiers fall back to `free`. Replace with JWT/OIDC middleware when real auth lands.
- `gateConsciousnessLevelOverride(body, caller)` — returns a 403 `FORBIDDEN_LEVEL_OVERRIDE` response when the payload contains `consciousness_level` and the caller is not admin/initiate. Returns `null` when the gate passes. Defense-in-depth alongside the resolver's own `ForbiddenLevelOverrideError`.

**Security boundary** is documented in the module header and cites the matching `SECURITY BOUNDARY` block in `scripts/integratedreading/level-resolver.ts` (and the design doc at `docs/plans/2026-05-15-consciousness-level-register-design.md` § Security boundary).

**Tests:** `tests/admin-auth-path.test.ts` — 14 cases covering header parsing, env-flag promotion, all four caller-identity permutations against the gate, and the no-op path when the field is absent.

## P2.4 — Endpoint level resolution (#77)

**Endpoints updated:**

- `POST /interpret` (`src/api/server.ts`)
- `POST /reading` (`src/standalone/standalone-api.ts`)
- `POST /reading/:engine_id` (`src/standalone/standalone-api.ts`)
- `POST /reading/stream` (SSE) (`src/standalone/standalone-api.ts`)

**Per endpoint:**

1. Server-side `deriveCallerIdentity()` from request headers
2. `gateConsciousnessLevelOverride()` short-circuits with 403 before the orchestrator runs
3. `resolveLevel({user_id, admin_override, caller_tier, caller_is_admin, default_level: 1, user_db_lookup})` produces `{effective_level, source, register_band}`
4. Resolved metadata attached to every successful response. The SSE stream emits a `level` event before `layer1`.

**Stored-level lookup:** `StandaloneApiConfig.get_user_consciousness_level(userId)` and `ApiDependencies.getUserConsciousnessLevel` are the injection points. Both have **TODO** comments noting they await the Selemene user-profile schema — until then, the resolver falls back to default level 1 with `level_source: 'default'`.

**Tests:** `tests/api-endpoints-level.test.ts` — 11 cases covering `/reading` (default, user_db, admin L3, admin L5, non-admin 403, invalid level 400, regression no-field), `/reading/:engine_id` (gate fires before engine; invalid engine still 400), and `/reading/stream` (level SSE event; non-admin error SSE event).

## Deviations from the brief

The brief described `POST /reading` / `POST /reading/:engine_id` / `POST /reading/stream` in `src/api/server.ts`. In reality those endpoints only exist in `src/standalone/standalone-api.ts`; `src/api/server.ts` exposes `/interpret`, `/heartbeat`, `/mirror`. I therefore wired:

- The full gate+resolver pattern into the four endpoints that actually exist (`/interpret` in `server.ts`; `/reading`, `/reading/:engine_id`, `/reading/stream` in `standalone-api.ts`).
- The new `src/api/auth.ts` module is shared by both surfaces.

The two engineReading happy-path tests use the policy-edge tactic (gate fires before the network call) because `generateEngineReading()` hits a live Selemene URL in unit tests. The successful resolver path is fully exercised by `/reading` whose orchestrator runs against in-process stubs.

## Acceptance gates

- `node --import tsx --test tests/*.test.ts` → **582 tests, 0 failures** (was 557 before, +25 new)
- `npx tsc -p tsconfig.json --noEmit` → only the pre-existing rootDir warning on `src/types/reading-request.ts`; no new errors
- No regressions in `tests/consciousness-level-contracts.test.ts` or `tests/standalone.test.ts`

## Test plan

- [ ] Confirm 403 path: `curl -X POST .../reading -d '{"birth_date":"1991-08-13","consciousness_level":5}'` → 403 FORBIDDEN_LEVEL_OVERRIDE
- [ ] Confirm admin path: same request with `-H 'X-Caller-Tier: initiate'` → 200 with `effective_consciousness_level: 5`, `level_source: 'admin_override'`, `register_band: 'l4_l5'`
- [ ] Confirm default path: `curl -X POST .../reading -d '{"birth_date":"1991-08-13"}'` → 200 with `effective_consciousness_level: 1`, `level_source: 'default'`, `register_band: 'l1_l3'`
- [ ] Confirm dev escape hatch: `WITNESS_DEV_ADMIN=1 npm run dev` → any caller can override (local only)
- [ ] Verify SSE: stream endpoint emits a `level` event before `layer1`

Closes #78
Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)